### PR TITLE
Add option to enable disable error reporting in FoliCon

### DIFF
--- a/FoliCon/App.xaml.cs
+++ b/FoliCon/App.xaml.cs
@@ -2,7 +2,6 @@
 using NLog;
 using Prism.Ioc;
 using Sentry;
-using Sentry.NLog;
 using Logger = NLog.Logger;
 
 namespace FoliCon;
@@ -12,7 +11,7 @@ namespace FoliCon;
 /// </summary>
 public partial class App
 {
-    private static Logger _logger = LogManager.GetCurrentClassLogger();
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
     protected override System.Windows.Window CreateShell()
     {
         return Container.Resolve<MainWindow>();
@@ -24,7 +23,7 @@ public partial class App
         LogManager.Configuration = Util.GetNLogConfig();
         DispatcherUnhandledException += App_DispatcherUnhandledException;
         GlobalDataHelper.Load<AppConfig>();
-        _logger.Info("FoliCon Initilized");
+        Logger.Info("FoliCon Initilized");
     }
 
     protected override void RegisterTypes(IContainerRegistry containerRegistry)

--- a/FoliCon/Modules/Extensions.cs
+++ b/FoliCon/Modules/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using NLog;
+using NLog.Config;
 using Logger = NLog.Logger;
 
 namespace FoliCon.Modules;
@@ -43,5 +44,25 @@ public static class Extensions
             Logger.Trace("GetBitmap from HttpResponseMessage - done");
             return bitmap;
         });
+    }
+
+    public static void SentryConfig(this LoggingConfiguration config, bool enableSentry)
+    {
+        var target = config.AllTargets.FirstOrDefault(t => t.Name.Equals("sentry", StringComparison.OrdinalIgnoreCase));
+        if (enableSentry && target is null)
+        {
+            var sentryTarget = Util.GetSentryTarget();
+            config.AddTarget(sentryTarget);
+            config.AddRuleForAllLevels(sentryTarget);
+            LogManager.Configuration = config;
+            Logger.Debug("Sentry enabled");
+        }
+        else
+        {
+            if (target == null) return;
+            config.RemoveTarget("sentry");
+            LogManager.Configuration = config;
+            Logger.Debug("Sentry disabled");
+        }
     }
 }

--- a/FoliCon/Modules/LangProvider.cs
+++ b/FoliCon/Modules/LangProvider.cs
@@ -69,6 +69,8 @@ public class LangProvider : INotifyPropertyChanged
             OnPropertyChanged(nameof(DownloadingIconWithCount));
             OnPropertyChanged(nameof(DownloadIt));
             OnPropertyChanged(nameof(EmptyDirectory));
+            OnPropertyChanged(nameof(EnableErrorReporting));
+            OnPropertyChanged(nameof(EnableErrorReportingTip));
             OnPropertyChanged(nameof(English));
             OnPropertyChanged(nameof(EnterTitlePlaceholder));
             OnPropertyChanged(nameof(FailedFileAccessAt));
@@ -250,7 +252,8 @@ public class LangProvider : INotifyPropertyChanged
     public string DownloadIt => Lang.DownloadIt;
 
     public string EmptyDirectory => Lang.EmptyDirectory;
-
+    public string EnableErrorReporting => Lang.EnableErrorReporting;
+    public string EnableErrorReportingTip => Lang.EnableErrorReportingTip;
     public string English => Lang.English;
 
     public string EnterTitlePlaceholder => Lang.EnterTitlePlaceholder;
@@ -527,7 +530,9 @@ public class LangKeys
     public static string DownloadIt = nameof(DownloadIt);
 
     public static string EmptyDirectory = nameof(EmptyDirectory);
-
+    public static string EnableErrorReporting = nameof(EnableErrorReporting);
+    public static string EnableErrorReportingTip = nameof(EnableErrorReportingTip);
+    
     public static string English = nameof(English);
 
     public static string EnterTitlePlaceholder = nameof(EnterTitlePlaceholder);

--- a/FoliCon/Properties/Langs/Lang.Designer.cs
+++ b/FoliCon/Properties/Langs/Lang.Designer.cs
@@ -457,6 +457,24 @@ namespace FoliCon.Properties.Langs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable Error reporting.
+        /// </summary>
+        public static string EnableErrorReporting {
+            get {
+                return ResourceManager.GetString("EnableErrorReporting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Send error reports to help improve FoliCon.
+        /// </summary>
+        public static string EnableErrorReportingTip {
+            get {
+                return ResourceManager.GetString("EnableErrorReportingTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to English.
         /// </summary>
         public static string English {

--- a/FoliCon/Properties/Langs/Lang.ar.resx
+++ b/FoliCon/Properties/Langs/Lang.ar.resx
@@ -561,4 +561,10 @@
   <data name="WritePermissionNotAllowed" xml:space="preserve">
     <value>لا يوجد إذن كتابة</value>
   </data>
+  <data name="EnableErrorReporting" xml:space="preserve">
+    <value>تمكين الإبلاغ عن الأخطاء</value>
+  </data>
+  <data name="EnableErrorReportingTip" xml:space="preserve">
+    <value>إرسال تقارير الأخطاء للمساعدة في تحسين FoliCon</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.es.resx
+++ b/FoliCon/Properties/Langs/Lang.es.resx
@@ -561,4 +561,10 @@ Esto ayuda a folicon a identificar los medios sin tener que elegir entre título
   <data name="WritePermissionNotAllowed" xml:space="preserve">
     <value>Sin permiso de escritura</value>
   </data>
+  <data name="EnableErrorReporting" xml:space="preserve">
+    <value>Habilitar informes de errores</value>
+  </data>
+  <data name="EnableErrorReportingTip" xml:space="preserve">
+    <value>Enviar informes de error para ayudar a mejorar FoliCon</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.hi.resx
+++ b/FoliCon/Properties/Langs/Lang.hi.resx
@@ -561,4 +561,10 @@
   <data name="WritePermissionNotAllowed" xml:space="preserve">
     <value>फोल्डर एक्सेस प्राप्त नही</value>
   </data>
+  <data name="EnableErrorReporting" xml:space="preserve">
+    <value>त्रुटि रिपोर्टिंग शुरू करें</value>
+  </data>
+  <data name="EnableErrorReportingTip" xml:space="preserve">
+    <value>FoliCon को बेहतर बनाने में मदद के लिए त्रुटि रिपोर्ट भेजें</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.resx
+++ b/FoliCon/Properties/Langs/Lang.resx
@@ -560,4 +560,10 @@ and refresh Icon Cache?</value>
   <data name="WritePermissionNotAllowed" xml:space="preserve">
     <value>No Write Permission</value>
   </data>
+  <data name="EnableErrorReporting" xml:space="preserve">
+    <value>Enable Error reporting</value>
+  </data>
+  <data name="EnableErrorReportingTip" xml:space="preserve">
+    <value>Send error reports to help improve FoliCon</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.ru.resx
+++ b/FoliCon/Properties/Langs/Lang.ru.resx
@@ -562,4 +562,12 @@
     <value>Нет разрешения на запись
 </value>
   </data>
+  <data name="EnableErrorReporting" xml:space="preserve">
+    <value>Включить отчеты об ошибках
+</value>
+  </data>
+  <data name="EnableErrorReportingTip" xml:space="preserve">
+    <value>Отправлять отчеты об ошибках, чтобы помочь улучшить FoliCon
+</value>
+  </data>
 </root>

--- a/FoliCon/ViewModels/MainWindowViewModel.cs
+++ b/FoliCon/ViewModels/MainWindowViewModel.cs
@@ -25,6 +25,7 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
     private Tmdb _tmdbObject;
     private DArt _dArtObject;
     private bool _isPosterWindowShown;
+    private bool _enableErrorReporting;
 
     private string _tmdbapiKey;
     private string _igdbClientId;
@@ -46,6 +47,15 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
     }
     private bool _isSkipAmbiguousEnabled;
     public bool IsSkipAmbiguousEnabled { get => _isSkipAmbiguousEnabled; set => SetProperty(ref _isSkipAmbiguousEnabled, value); }
+    public bool EnableErrorReporting
+    {
+        get => _enableErrorReporting;
+        set
+        {
+            LogManager.Configuration.SentryConfig(value);
+            SetProperty(ref _enableErrorReporting, value);
+        }
+    }
 
     public bool IsSearchModeVisible
     {
@@ -202,6 +212,7 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
             .Property(p => p.IsPosterMockupUsed, true)
             .Property(p => p.IsPosterWindowShown, false)
             .Property(p => p.AppLanguage, Languages.English)
+            .Property(p => p.EnableErrorReporting, false)
             .PersistOn(nameof(PropertyChanged));
         Services.Tracker.Track(this);
         var selectedLanguage = AppLanguage;

--- a/FoliCon/Views/MainWindow.xaml
+++ b/FoliCon/Views/MainWindow.xaml
@@ -102,6 +102,8 @@
                         </hc:Interaction.Triggers>
                     </MenuItem>
                     <MenuItem Header="{ex:Lang Key={x:Static langs:LangKeys.CheckForUpdate}}" Command="{Binding UpdateCommand}" />
+                    <MenuItem Header="{ex:Lang Key={x:Static langs:LangKeys.EnableErrorReporting}}" ToolTip="{ex:Lang Key={x:Static langs:LangKeys.EnableErrorReportingTip}}" Command="{Binding }"
+                              IsCheckable="True" IsChecked="{Binding EnableErrorReporting}"/>
                     <MenuItem Header="{ex:Lang Key={x:Static langs:LangKeys.About}}" Command="{Binding AboutCommand}" />
                 </MenuItem>
             </Menu>


### PR DESCRIPTION
enabling this option will send the exception report to developer via Sentry