### PR TITLE
Feature: Feature to extract Deviations from DeviantArt, so that in professional mode, use can pick from images, that are in an compressed archive

### DIFF
--- a/FoliCon/App.xaml.cs
+++ b/FoliCon/App.xaml.cs
@@ -38,6 +38,7 @@ public partial class App
         containerRegistry.RegisterDialog<CustomIconControl, CustomIconControlViewModel>("CustomIcon");
         containerRegistry.RegisterDialog<PosterIconConfig, PosterIconConfigViewModel>("PosterIconConfig");
         containerRegistry.RegisterDialog<SubfolderProcessing, SubfolderProcessingViewModel>("SubfolderProcessingConfig");
+        containerRegistry.RegisterDialog<ManualExplorer, ManualExplorerViewModel>("ManualExplorer");
         containerRegistry.RegisterDialog<AboutBox, AboutBoxViewModel>("AboutBox");
         containerRegistry.RegisterDialog<PosterPicker, PosterPickerViewModel>("PosterPicker");
         containerRegistry.RegisterDialog<Previewer, PreviewerViewModel>("Previewer");

--- a/FoliCon/FoliCon.csproj
+++ b/FoliCon/FoliCon.csproj
@@ -40,6 +40,7 @@ dineshsolanki.github.io/folicon/</Description>
     <PackageReference Include="Prism.DryIoc" Version="8.1.97" />
     <PackageReference Include="Sentry" Version="4.8.1" />
     <PackageReference Include="Sentry.NLog" Version="4.8.1" />
+    <PackageReference Include="SharpCompress" Version="0.37.2" />
     <PackageReference Include="TMDbLib" Version="2.2.0" />
     <PackageReference Include="Vanara.PInvoke.Shell32" Version="4.0.2" />
     <PackageReference Include="WinCopies.IconLib" Version="0.75.0-rc" />

--- a/FoliCon/Models/Api/DArtDownloadResponse.cs
+++ b/FoliCon/Models/Api/DArtDownloadResponse.cs
@@ -18,21 +18,10 @@ public record DArtDownloadResponse
     public int FileSizeBytes { get; init; }
     
     [JsonIgnore]
-    public string localDownloadPath { get; set; }
+    public string LocalDownloadPath { get; set; }
     
     public string GetFileSizeHumanReadable()
     {
-        if (FileSizeBytes < 1024)
-            return $"{FileSizeBytes} bytes";
-        
-        int i;
-        double fileSizeToDouble = FileSizeBytes;
-
-        for (i = 0; i < 8 && fileSizeToDouble >= 1024; ++i)
-        {
-            fileSizeToDouble /= 1024;
-        }
-
-        return $"{fileSizeToDouble:0.##} {new[] {"bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}[i]}";
+        return ConvertHelper.ToFileSize(FileSizeBytes);
     }
 }

--- a/FoliCon/Models/Api/DArtDownloadResponse.cs
+++ b/FoliCon/Models/Api/DArtDownloadResponse.cs
@@ -1,0 +1,38 @@
+﻿namespace FoliCon.Models.Api;
+
+public record DArtDownloadResponse
+{
+    [JsonProperty("src")]
+    public string Src { get; init; }
+
+    [JsonProperty("filename")]
+    public string Filename { get; init; }
+
+    [JsonProperty("width")]
+    public int Width { get; init; }
+
+    [JsonProperty("height")]
+    public int Height { get; init; }
+
+    [JsonProperty("filesize")]
+    public int FileSizeBytes { get; init; }
+    
+    [JsonIgnore]
+    public string localDownloadPath { get; set; }
+    
+    public string GetFileSizeHumanReadable()
+    {
+        if (FileSizeBytes < 1024)
+            return $"{FileSizeBytes} bytes";
+        
+        int i;
+        double fileSizeToDouble = FileSizeBytes;
+
+        for (i = 0; i < 8 && fileSizeToDouble >= 1024; ++i)
+        {
+            fileSizeToDouble /= 1024;
+        }
+
+        return $"{fileSizeToDouble:0.##} {new[] {"bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}[i]}";
+    }
+}

--- a/FoliCon/Models/Data/DArtImageList.cs
+++ b/FoliCon/Models/Data/DArtImageList.cs
@@ -4,6 +4,7 @@ public class DArtImageList : BindableBase
 {
     private string _url;
     private BitmapSource _image;
+    private string _deviationId;
 
     public DArtImageList(string url, BitmapSource bmp)
     {
@@ -11,6 +12,14 @@ public class DArtImageList : BindableBase
         Image = bmp ?? throw new ArgumentNullException(nameof(bmp));
     }
 
+    public DArtImageList(string url, BitmapSource bmp, string deviationId)
+    {
+        Url = url ?? throw new ArgumentNullException(nameof(url));
+        Image = bmp ?? throw new ArgumentNullException(nameof(bmp));
+        DeviationId = deviationId ?? throw new ArgumentNullException(nameof(deviationId));
+    }
+    
     public string Url { get => _url; set => SetProperty(ref _url, value); }
     public BitmapSource Image { get => _image; set => SetProperty(ref _image, value); }
+    public string DeviationId { get => _deviationId; set => SetProperty(ref _deviationId, value); }
 }

--- a/FoliCon/Models/Data/DArtImageList.cs
+++ b/FoliCon/Models/Data/DArtImageList.cs
@@ -12,10 +12,8 @@ public class DArtImageList : BindableBase
         Image = bmp ?? throw new ArgumentNullException(nameof(bmp));
     }
 
-    public DArtImageList(string url, BitmapSource bmp, string deviationId)
+    public DArtImageList(string url, BitmapSource bmp, string deviationId) : this(url, bmp)
     {
-        Url = url ?? throw new ArgumentNullException(nameof(url));
-        Image = bmp ?? throw new ArgumentNullException(nameof(bmp));
         DeviationId = deviationId ?? throw new ArgumentNullException(nameof(deviationId));
     }
     

--- a/FoliCon/Modules/DeviantArt/DArt.cs
+++ b/FoliCon/Modules/DeviantArt/DArt.cs
@@ -92,7 +92,12 @@ public class DArt : BindableBase
 
         return result;        
     }
-    
+
+    /// <summary>
+    /// Downloads a file from the DeviantArt API.
+    /// </summary>
+    /// <param name="deviationId">The ID of the deviation.</param>
+    /// <returns>The DArtDownloadResponse object containing the download details.</returns>
     public async Task<DArtDownloadResponse> Download(string deviationId)
     {
         GetClientAccessTokenAsync();

--- a/FoliCon/Modules/DeviantArt/DArt.cs
+++ b/FoliCon/Modules/DeviantArt/DArt.cs
@@ -98,7 +98,7 @@ public class DArt : BindableBase
         GetClientAccessTokenAsync();
         var dArtDownloadResponse = await GetDArtDownloadResponseAsync(deviationId);
         var targetDirectoryPath = FileUtils.CreateDirectoryInFoliConTemp(deviationId);
-        dArtDownloadResponse.localDownloadPath = targetDirectoryPath;
+        dArtDownloadResponse.LocalDownloadPath = targetDirectoryPath;
         var downloadResponse = await Services.HttpC.GetAsync(dArtDownloadResponse.Src);
         
         if (FileUtils.IsCompressedArchive(dArtDownloadResponse.Filename))

--- a/FoliCon/Modules/DeviantArt/DArt.cs
+++ b/FoliCon/Modules/DeviantArt/DArt.cs
@@ -1,6 +1,9 @@
 ﻿using FoliCon.Models.Api;
 using FoliCon.Modules.Configuration;
+using FoliCon.Modules.utils;
 using Microsoft.Extensions.Caching.Memory;
+using SharpCompress.Common;
+using SharpCompress.Readers;
 
 namespace FoliCon.Modules.DeviantArt;
 
@@ -12,6 +15,8 @@ public class DArt : BindableBase
     
     private readonly MemoryCache _cache = new(new MemoryCacheOptions());
 
+    private static readonly JsonSerializerSettings SerializerSettings = new() { NullValueHandling = NullValueHandling.Ignore };
+    
     public string ClientId
     {
         get => _clientId;
@@ -83,16 +88,15 @@ public class DArt : BindableBase
         var url = GetBrowseApiUrl(query, offset);
         using var response = await Services.HttpC.GetAsync(new Uri(url));
         var jsonData = await response.Content.ReadAsStringAsync();
-
-        var serializerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
-        var result = JsonConvert.DeserializeObject<DArtBrowseResult>(jsonData, serializerSettings);
+        
+        var result = JsonConvert.DeserializeObject<DArtBrowseResult>(jsonData, SerializerSettings);
 
         return result;        
     }
 
     private static string GetPlaceboApiUrl(string clientAccessToken)
     {
-        return "https://www.deviantart.com/api/v1/oauth2/placebo?access_token=" + clientAccessToken;
+        return $"https://www.deviantart.com/api/v1/oauth2/placebo?access_token={clientAccessToken}";
     }
 
     private string GetTokenApiUrl()

--- a/FoliCon/Modules/DeviantArt/DArt.cs
+++ b/FoliCon/Modules/DeviantArt/DArt.cs
@@ -97,7 +97,7 @@ public class DArt : BindableBase
     {
         GetClientAccessTokenAsync();
         var dArtDownloadResponse = await GetDArtDownloadResponseAsync(deviationId);
-        var targetDirectoryPath = FileUtils.CreateDirectoryInFoliConTemp(dArtDownloadResponse.Filename);
+        var targetDirectoryPath = FileUtils.CreateDirectoryInFoliConTemp(deviationId);
         dArtDownloadResponse.localDownloadPath = targetDirectoryPath;
         var downloadResponse = await Services.HttpC.GetAsync(dArtDownloadResponse.Src);
         

--- a/FoliCon/Modules/Extension/DialogServiceExtensions.cs
+++ b/FoliCon/Modules/Extension/DialogServiceExtensions.cs
@@ -68,6 +68,17 @@ public static class DialogServiceExtensions
         Logger.Trace("ShowSubfolderProcessingConfig called");
         dialogService.ShowDialog("SubfolderProcessingConfig", callBack);
     }
+    
+    public static void ShowManualExplorer(this IDialogService dialogService, string deviationId,
+        DArt dartObject, Action<IDialogResult> callBack)
+    {
+        Logger.Trace("ShowManualExplorer called with deviationId: {DeviationId}", deviationId);
+        var p = new DialogParameters
+        {
+            {"DeviationId", deviationId}, {"dartobject", dartObject}
+        };
+        dialogService.ShowDialog("ManualExplorer", p, callBack);
+    }
 
     public static void ShowAboutBox(this IDialogService dialogService, Action<IDialogResult> callBack)
     {

--- a/FoliCon/Modules/Extension/StreamExtension.cs
+++ b/FoliCon/Modules/Extension/StreamExtension.cs
@@ -1,0 +1,33 @@
+﻿using FoliCon.Modules.utils;
+using SharpCompress.Common;
+using SharpCompress.Readers;
+
+namespace FoliCon.Modules.Extension;
+
+public static class StreamExtensions
+{
+    public static void ExtractPngAndIcoToDirectory(this Stream archiveStream, string targetPath)
+    {
+        using var reader = ReaderFactory.Open(archiveStream);
+        while (reader.MoveToNextEntry())
+        {
+            var entryKey = reader.Entry.Key;
+
+            if (entryKey != null && (reader.Entry.IsDirectory ||
+                                     entryKey.Contains("ResourceForks") ||
+                                     entryKey.Contains("__MACOSX") ||
+                                     entryKey.StartsWith("._") ||
+                                     entryKey.Equals(".DS_Store") ||
+                                     entryKey.Equals("Thumbs.db"))) continue;
+
+            if (FileUtils.IsPngOrIco(entryKey))
+            {
+                reader.WriteEntryToDirectory(targetPath, new ExtractionOptions
+                {
+                    ExtractFullPath = false,
+                    Overwrite = true
+                });
+            }
+        }
+    }
+}

--- a/FoliCon/Modules/Extension/StreamExtension.cs
+++ b/FoliCon/Modules/Extension/StreamExtension.cs
@@ -6,6 +6,11 @@ namespace FoliCon.Modules.Extension;
 
 public static class StreamExtensions
 {
+    /// <summary>
+    /// Extracts PNG and ICO files from a compressed stream and writes them to a directory.
+    /// </summary>
+    /// <param name="archiveStream">The compressed stream containing the PNG and ICO files.</param>
+    /// <param name="targetPath">The path of the directory where the extracted files should be written.</param>
     public static void ExtractPngAndIcoToDirectory(this Stream archiveStream, string targetPath)
     {
         using var reader = ReaderFactory.Open(archiveStream);

--- a/FoliCon/Modules/Extension/StreamExtension.cs
+++ b/FoliCon/Modules/Extension/StreamExtension.cs
@@ -12,13 +12,10 @@ public static class StreamExtensions
         while (reader.MoveToNextEntry())
         {
             var entryKey = reader.Entry.Key;
-
-            if (entryKey != null && (reader.Entry.IsDirectory ||
-                                     entryKey.Contains("ResourceForks") ||
-                                     entryKey.Contains("__MACOSX") ||
-                                     entryKey.StartsWith("._") ||
-                                     entryKey.Equals(".DS_Store") ||
-                                     entryKey.Equals("Thumbs.db"))) continue;
+            if (IsUnwantedDirectoryOrFileType(entryKey, reader))
+            {
+                continue;
+            }
 
             if (FileUtils.IsPngOrIco(entryKey))
             {
@@ -29,5 +26,15 @@ public static class StreamExtensions
                 });
             }
         }
+    }
+
+    private static bool IsUnwantedDirectoryOrFileType(string entryKey, IReader reader)
+    {
+        return entryKey != null && (reader.Entry.IsDirectory ||
+                                    entryKey.Contains("ResourceForks") ||
+                                    entryKey.Contains("__MACOSX") ||
+                                    entryKey.StartsWith("._") ||
+                                    entryKey.Equals(".DS_Store") ||
+                                    entryKey.Equals("Thumbs.db"));
     }
 }

--- a/FoliCon/Modules/LangProvider.cs
+++ b/FoliCon/Modules/LangProvider.cs
@@ -33,16 +33,16 @@ public class LangProvider : INotifyPropertyChanged
 
     private void UpdateLangs()
     {
+        OnPropertyChanged(nameof(APIKeysConfiguration));
+        OnPropertyChanged(nameof(APIKeysNotProvided));
         OnPropertyChanged(nameof(About));
         OnPropertyChanged(nameof(Action));
         OnPropertyChanged(nameof(AddToContextMenu));
         OnPropertyChanged(nameof(All));
         OnPropertyChanged(nameof(AlwaysShowPosterWindow));
         OnPropertyChanged(nameof(AmbiguousTitleTooltip));
-        OnPropertyChanged(nameof(APIKeysConfiguration));
-        OnPropertyChanged(nameof(APIKeysNotProvided));
-        OnPropertyChanged(nameof(Apply));
         OnPropertyChanged(nameof(AppWillClose));
+        OnPropertyChanged(nameof(Apply));
         OnPropertyChanged(nameof(Arabic));
         OnPropertyChanged(nameof(Auto));
         OnPropertyChanged(nameof(BestSuitedForHorizontal));
@@ -76,18 +76,19 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(DeleteMediaInfoTooltip));
         OnPropertyChanged(nameof(DevelopedByDinesh));
         OnPropertyChanged(nameof(DirectoryIsEmpty));
-        OnPropertyChanged(nameof(DownloadingIcons));
-        OnPropertyChanged(nameof(DownloadingIconWithCount));
         OnPropertyChanged(nameof(DownloadIt));
+        OnPropertyChanged(nameof(DownloadingIconWithCount));
+        OnPropertyChanged(nameof(DownloadingIcons));
         OnPropertyChanged(nameof(EmptyDirectory));
-        OnPropertyChanged(nameof(Enabled));
         OnPropertyChanged(nameof(EnableErrorReporting));
         OnPropertyChanged(nameof(EnableErrorReportingTip));
         OnPropertyChanged(nameof(EnableSubfolderProcessing));
+        OnPropertyChanged(nameof(Enabled));
         OnPropertyChanged(nameof(English));
         OnPropertyChanged(nameof(EnterTitlePlaceholder));
         OnPropertyChanged(nameof(EnterValidRegexPlaceholder));
         OnPropertyChanged(nameof(ExplorerIntegration));
+        OnPropertyChanged(nameof(ExtractManually));
         OnPropertyChanged(nameof(FailedFileAccessAt));
         OnPropertyChanged(nameof(FailedToSaveMediaInfoAt));
         OnPropertyChanged(nameof(FileIsInUse));
@@ -121,6 +122,7 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(Load));
         OnPropertyChanged(nameof(LoadingPosters));
         OnPropertyChanged(nameof(MakeIcons));
+        OnPropertyChanged(nameof(ManualExplorer));
         OnPropertyChanged(nameof(MediaRating));
         OnPropertyChanged(nameof(MediaTitle));
         OnPropertyChanged(nameof(Movie));
@@ -160,11 +162,11 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(RestartExplorerTooltip));
         OnPropertyChanged(nameof(Russian));
         OnPropertyChanged(nameof(Save));
+        OnPropertyChanged(nameof(SearchMode));
+        OnPropertyChanged(nameof(SearchResult));
         OnPropertyChanged(nameof(Searching));
         OnPropertyChanged(nameof(SearchingWithCount));
         OnPropertyChanged(nameof(SearchingWithName));
-        OnPropertyChanged(nameof(SearchMode));
-        OnPropertyChanged(nameof(SearchResult));
         OnPropertyChanged(nameof(SeeMorePosters));
         OnPropertyChanged(nameof(SelectFolder));
         OnPropertyChanged(nameof(SelectIconsDirectory));
@@ -180,6 +182,8 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(Spanish));
         OnPropertyChanged(nameof(StopSearching));
         OnPropertyChanged(nameof(SubfolderProcessing));
+        OnPropertyChanged(nameof(TMDBAPIKey));
+        OnPropertyChanged(nameof(TV));
         OnPropertyChanged(nameof(Test));
         OnPropertyChanged(nameof(Theme));
         OnPropertyChanged(nameof(ThemeDark));
@@ -187,9 +191,7 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(ThemeSystem));
         OnPropertyChanged(nameof(ThisIsLatestVersion));
         OnPropertyChanged(nameof(Title));
-        OnPropertyChanged(nameof(TMDBAPIKey));
         OnPropertyChanged(nameof(ToForceReload));
-        OnPropertyChanged(nameof(TV));
         OnPropertyChanged(nameof(UnauthorizedAccess));
         OnPropertyChanged(nameof(Undo));
         OnPropertyChanged(nameof(UndoSuccessful));
@@ -204,16 +206,16 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(Year));
     }
 
+    public string APIKeysConfiguration => Lang.APIKeysConfiguration;
+    public string APIKeysNotProvided => Lang.APIKeysNotProvided;
     public string About => Lang.About;
     public string Action => Lang.Action;
     public string AddToContextMenu => Lang.AddToContextMenu;
     public string All => Lang.All;
     public string AlwaysShowPosterWindow => Lang.AlwaysShowPosterWindow;
     public string AmbiguousTitleTooltip => Lang.AmbiguousTitleTooltip;
-    public string APIKeysConfiguration => Lang.APIKeysConfiguration;
-    public string APIKeysNotProvided => Lang.APIKeysNotProvided;
-    public string Apply => Lang.Apply;
     public string AppWillClose => Lang.AppWillClose;
+    public string Apply => Lang.Apply;
     public string Arabic => Lang.Arabic;
     public string Auto => Lang.Auto;
     public string BestSuitedForHorizontal => Lang.BestSuitedForHorizontal;
@@ -247,19 +249,20 @@ public class LangProvider : INotifyPropertyChanged
     public string DeleteMediaInfoTooltip => Lang.DeleteMediaInfoTooltip;
     public string DevelopedByDinesh => Lang.DevelopedByDinesh;
     public string DirectoryIsEmpty => Lang.DirectoryIsEmpty;
-    public string DownloadingIcons => Lang.DownloadingIcons;
-    public string DownloadingIconWithCount => Lang.DownloadingIconWithCount;
     public string DownloadIt => Lang.DownloadIt;
+    public string DownloadingIconWithCount => Lang.DownloadingIconWithCount;
+    public string DownloadingIcons => Lang.DownloadingIcons;
     public string EmptyDirectory => Lang.EmptyDirectory;
-    public string Enabled => Lang.Enabled;
     public string EnableErrorReporting => Lang.EnableErrorReporting;
     public string EnableErrorReportingTip => Lang.EnableErrorReportingTip;
     public string EnableSubfolderProcessing => Lang.EnableSubfolderProcessing;
+    public string Enabled => Lang.Enabled;
     public string English => Lang.English;
     public string EnterTitlePlaceholder => Lang.EnterTitlePlaceholder;
     public string EnterValidRegexPlaceholder => Lang.EnterValidRegexPlaceholder;
     public string ExceptionOccurred => Lang.ExceptionOccurred;
     public string ExplorerIntegration => Lang.ExplorerIntegration;
+    public string ExtractManually => Lang.ExtractManually;
     public string FailedFileAccessAt => Lang.FailedFileAccessAt;
     public string FailedToSaveMediaInfoAt => Lang.FailedToSaveMediaInfoAt;
     public string FileIsInUse => Lang.FileIsInUse;
@@ -293,6 +296,7 @@ public class LangProvider : INotifyPropertyChanged
     public string Load => Lang.Load;
     public string LoadingPosters => Lang.LoadingPosters;
     public string MakeIcons => Lang.MakeIcons;
+    public string ManualExplorer => Lang.ManualExplorer;
     public string MediaRating => Lang.MediaRating;
     public string MediaTitle => Lang.MediaTitle;
     public string Movie => Lang.Movie;
@@ -332,11 +336,11 @@ public class LangProvider : INotifyPropertyChanged
     public string RestartExplorerTooltip => Lang.RestartExplorerTooltip;
     public string Russian => Lang.Russian;
     public string Save => Lang.Save;
+    public string SearchMode => Lang.SearchMode;
+    public string SearchResult => Lang.SearchResult;
     public string Searching => Lang.Searching;
     public string SearchingWithCount => Lang.SearchingWithCount;
     public string SearchingWithName => Lang.SearchingWithName;
-    public string SearchMode => Lang.SearchMode;
-    public string SearchResult => Lang.SearchResult;
     public string SeeMorePosters => Lang.SeeMorePosters;
     public string SelectFolder => Lang.SelectFolder;
     public string SelectIconsDirectory => Lang.SelectIconsDirectory;
@@ -352,6 +356,8 @@ public class LangProvider : INotifyPropertyChanged
     public string Spanish => Lang.Spanish;
     public string StopSearching => Lang.StopSearching;
     public string SubfolderProcessing => Lang.SubfolderProcessing;
+    public string TMDBAPIKey => Lang.TMDBAPIKey;
+    public string TV => Lang.TV;
     public string Test => Lang.Test;
     public string Theme => Lang.Theme;
     public string ThemeDark => Lang.ThemeDark;
@@ -359,9 +365,7 @@ public class LangProvider : INotifyPropertyChanged
     public string ThemeSystem => Lang.ThemeSystem;
     public string ThisIsLatestVersion => Lang.ThisIsLatestVersion;
     public string Title => Lang.Title;
-    public string TMDBAPIKey => Lang.TMDBAPIKey;
     public string ToForceReload => Lang.ToForceReload;
-    public string TV => Lang.TV;
     public string UnauthorizedAccess => Lang.UnauthorizedAccess;
     public string Undo => Lang.Undo;
     public string UndoSuccessful => Lang.UndoSuccessful;
@@ -384,16 +388,16 @@ public class LangProvider : INotifyPropertyChanged
 
 public class LangKeys
 {
+    public static string APIKeysConfiguration = nameof(APIKeysConfiguration);
+    public static string APIKeysNotProvided = nameof(APIKeysNotProvided);
     public static string About = nameof(About);
     public static string Action = nameof(Action);
     public static string AddToContextMenu = nameof(AddToContextMenu);
     public static string All = nameof(All);
     public static string AlwaysShowPosterWindow = nameof(AlwaysShowPosterWindow);
     public static string AmbiguousTitleTooltip = nameof(AmbiguousTitleTooltip);
-    public static string APIKeysConfiguration = nameof(APIKeysConfiguration);
-    public static string APIKeysNotProvided = nameof(APIKeysNotProvided);
-    public static string Apply = nameof(Apply);
     public static string AppWillClose = nameof(AppWillClose);
+    public static string Apply = nameof(Apply);
     public static string Arabic = nameof(Arabic);
     public static string Auto = nameof(Auto);
     public static string BestSuitedForHorizontal = nameof(BestSuitedForHorizontal);
@@ -427,19 +431,20 @@ public class LangKeys
     public static string DeleteMediaInfoTooltip = nameof(DeleteMediaInfoTooltip);
     public static string DevelopedByDinesh = nameof(DevelopedByDinesh);
     public static string DirectoryIsEmpty = nameof(DirectoryIsEmpty);
-    public static string DownloadingIcons = nameof(DownloadingIcons);
-    public static string DownloadingIconWithCount = nameof(DownloadingIconWithCount);
     public static string DownloadIt = nameof(DownloadIt);
+    public static string DownloadingIconWithCount = nameof(DownloadingIconWithCount);
+    public static string DownloadingIcons = nameof(DownloadingIcons);
     public static string EmptyDirectory = nameof(EmptyDirectory);
-    public static string Enabled = nameof(Enabled);
     public static string EnableErrorReporting = nameof(EnableErrorReporting);
     public static string EnableErrorReportingTip = nameof(EnableErrorReportingTip);
     public static string EnableSubfolderProcessing = nameof(EnableSubfolderProcessing);
+    public static string Enabled = nameof(Enabled);
     public static string English = nameof(English);
     public static string EnterTitlePlaceholder = nameof(EnterTitlePlaceholder);
     public static string EnterValidRegexPlaceholder = nameof(EnterValidRegexPlaceholder);
     public static string ExceptionOccurred = nameof(ExceptionOccurred);
     public static string ExplorerIntegration = nameof(ExplorerIntegration);
+    public static string ExtractManually = nameof(ExtractManually);
     public static string FailedFileAccessAt = nameof(FailedFileAccessAt);
     public static string FailedToSaveMediaInfoAt = nameof(FailedToSaveMediaInfoAt);
     public static string FileIsInUse = nameof(FileIsInUse);
@@ -473,6 +478,7 @@ public class LangKeys
     public static string Load = nameof(Load);
     public static string LoadingPosters = nameof(LoadingPosters);
     public static string MakeIcons = nameof(MakeIcons);
+    public static string ManualExplorer = nameof(ManualExplorer);
     public static string MediaRating = nameof(MediaRating);
     public static string MediaTitle = nameof(MediaTitle);
     public static string Movie = nameof(Movie);
@@ -512,11 +518,11 @@ public class LangKeys
     public static string RestartExplorerTooltip = nameof(RestartExplorerTooltip);
     public static string Russian = nameof(Russian);
     public static string Save = nameof(Save);
+    public static string SearchMode = nameof(SearchMode);
+    public static string SearchResult = nameof(SearchResult);
     public static string Searching = nameof(Searching);
     public static string SearchingWithCount = nameof(SearchingWithCount);
     public static string SearchingWithName = nameof(SearchingWithName);
-    public static string SearchMode = nameof(SearchMode);
-    public static string SearchResult = nameof(SearchResult);
     public static string SeeMorePosters = nameof(SeeMorePosters);
     public static string SelectFolder = nameof(SelectFolder);
     public static string SelectIconsDirectory = nameof(SelectIconsDirectory);
@@ -532,6 +538,8 @@ public class LangKeys
     public static string Spanish = nameof(Spanish);
     public static string StopSearching = nameof(StopSearching);
     public static string SubfolderProcessing = nameof(SubfolderProcessing);
+    public static string TMDBAPIKey = nameof(TMDBAPIKey);
+    public static string TV = nameof(TV);
     public static string Test = nameof(Test);
     public static string Theme = nameof(Theme);
     public static string ThemeDark = nameof(ThemeDark);
@@ -539,9 +547,7 @@ public class LangKeys
     public static string ThemeSystem = nameof(ThemeSystem);
     public static string ThisIsLatestVersion = nameof(ThisIsLatestVersion);
     public static string Title = nameof(Title);
-    public static string TMDBAPIKey = nameof(TMDBAPIKey);
     public static string ToForceReload = nameof(ToForceReload);
-    public static string TV = nameof(TV);
     public static string UnauthorizedAccess = nameof(UnauthorizedAccess);
     public static string Undo = nameof(Undo);
     public static string UndoSuccessful = nameof(UndoSuccessful);

--- a/FoliCon/Modules/utils/FileUtils.cs
+++ b/FoliCon/Modules/utils/FileUtils.cs
@@ -482,7 +482,7 @@ public static class FileUtils
 
     public static string CreateDirectoryInFoliConTemp(string path)
     {
-        var foliConTempPath = FoliConTempPath();
+        var foliConTempPath = FoliConTempDeviationsPath();
         var fullPath = Path.Combine(foliConTempPath, path);
         CreateDirectory(fullPath);
         return fullPath;
@@ -504,8 +504,25 @@ public static class FileUtils
         }
     }
     
+    public static void DeleteFoliConTempDeviationDirectory(bool ifEmpty = false)
+    {
+        if (ifEmpty)
+        {
+            DeleteDirectoryIfEmpty(FoliConTempDeviationsPath());
+        }
+        else
+        {
+            Directory.Delete(FoliConTempDeviationsPath(), true);
+        }
+    }
+    
     private static string FoliConTempPath()
     {
         return Path.Combine(Path.GetTempPath(), "FoliCon");
+    }
+    
+    private static string FoliConTempDeviationsPath()
+    {
+        return Path.Combine(FoliConTempPath(), "Deviations");
     }
 }

--- a/FoliCon/Modules/utils/FileUtils.cs
+++ b/FoliCon/Modules/utils/FileUtils.cs
@@ -15,7 +15,7 @@ namespace FoliCon.Modules.utils;
 public static class FileUtils
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-    private static readonly List<string> _compressedExtensions = [
+    private static readonly List<string> CompressedExtensions = [
         ".zip",
         ".rar",
         ".gz",
@@ -244,7 +244,11 @@ public static class FileUtils
     {
         var permissions = new DirectoryPermissionsResult();
 
-        if (!Directory.Exists(dirPath)) return permissions;
+        if (!Directory.Exists(dirPath))
+        {
+            return permissions;
+        }
+
         var identity = WindowsIdentity.GetCurrent();
         var principal = new WindowsPrincipal(identity);
 
@@ -256,7 +260,11 @@ public static class FileUtils
         {
             var securityIdentifier = (SecurityIdentifier) rule.IdentityReference;
 
-            if (!principal.IsInRole(securityIdentifier)) continue;
+            if (!principal.IsInRole(securityIdentifier))
+            {
+                continue;
+            }
+
             if ((FileSystemRights.Read & rule.FileSystemRights) != 0 && rule.AccessControlType == AccessControlType.Allow)
             {
                 permissions.CanRead = true;
@@ -491,30 +499,27 @@ public static class FileUtils
     public static bool IsCompressedArchive(string fileName)
     {
         var fileExtension = Path.GetExtension(fileName)?.ToLower();
-        return _compressedExtensions.Contains(fileExtension);
+        return CompressedExtensions.Contains(fileExtension);
     }
     
     public static void DeleteDirectoryIfEmpty(string targetDirectoryPath)
     {
-        if (!Directory.Exists(targetDirectoryPath)) return;
-        
+        if (!Directory.Exists(targetDirectoryPath))
+        {
+            return;
+        }
+
         if (Directory.GetFiles(targetDirectoryPath).Length == 0)
         {
             Directory.Delete(targetDirectoryPath);
         }
     }
-    
-    public static void DeleteFoliConTempDeviationDirectory(bool ifEmpty = false)
+
+    public static void DeleteFoliConTempDeviationDirectory()
     {
-        if (ifEmpty)
-        {
-            DeleteDirectoryIfEmpty(FoliConTempDeviationsPath());
-        }
-        else
-        {
-            Directory.Delete(FoliConTempDeviationsPath(), true);
-        }
+        Directory.Delete(FoliConTempDeviationsPath(), true);
     }
+    
     
     private static string FoliConTempPath()
     {

--- a/FoliCon/Properties/Langs/Lang.Designer.cs
+++ b/FoliCon/Properties/Langs/Lang.Designer.cs
@@ -574,6 +574,15 @@ namespace FoliCon.Properties.Langs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Extract manually.
+        /// </summary>
+        public static string ExtractManually {
+            get {
+                return ResourceManager.GetString("ExtractManually", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to access file at {0}. You may not have permission to access this file. Try running as admin..
         /// </summary>
         public static string FailedFileAccessAt {
@@ -869,6 +878,15 @@ namespace FoliCon.Properties.Langs {
         public static string MakeIcons {
             get {
                 return ResourceManager.GetString("MakeIcons", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manual Explorer.
+        /// </summary>
+        public static string ManualExplorer {
+            get {
+                return ResourceManager.GetString("ManualExplorer", resourceCulture);
             }
         }
         

--- a/FoliCon/Properties/Langs/Lang.ar.resx
+++ b/FoliCon/Properties/Langs/Lang.ar.resx
@@ -645,4 +645,10 @@
   <data name="Pattern" xml:space="preserve">
     <value>نمط</value>
   </data>
+  <data name="ManualExplorer" xml:space="preserve">
+    <value>المستكشف اليدوي</value>
+  </data>
+  <data name="ExtractManually" xml:space="preserve">
+    <value>استخراج يدوي</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.es.resx
+++ b/FoliCon/Properties/Langs/Lang.es.resx
@@ -645,4 +645,10 @@ Esto ayuda a folicon a identificar los medios sin tener que elegir entre título
   <data name="Pattern" xml:space="preserve">
     <value>Patrón</value>
   </data>
+  <data name="ManualExplorer" xml:space="preserve">
+    <value>Explorador manual</value>
+  </data>
+  <data name="ExtractManually" xml:space="preserve">
+    <value>Extraer manualmente</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.hi.resx
+++ b/FoliCon/Properties/Langs/Lang.hi.resx
@@ -645,4 +645,10 @@
   <data name="Pattern" xml:space="preserve">
     <value>पैटर्न</value>
   </data>
+  <data name="ManualExplorer" xml:space="preserve">
+    <value>मैनुअल एक्सप्लोरर</value>
+  </data>
+  <data name="ExtractManually" xml:space="preserve">
+    <value>एक्सट्रेक्ट करे</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.pt.resx
+++ b/FoliCon/Properties/Langs/Lang.pt.resx
@@ -644,4 +644,10 @@ e renovar o cache dos Ícones?</value>
   <data name="Pattern" xml:space="preserve">
     <value>Padrão</value>
   </data>
+  <data name="ManualExplorer" xml:space="preserve">
+    <value>Explorador manual</value>
+  </data>
+  <data name="ExtractManually" xml:space="preserve">
+    <value>Extrair manualmente</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.resx
+++ b/FoliCon/Properties/Langs/Lang.resx
@@ -649,4 +649,10 @@ and refresh Icon Cache?</value>
     <data name="Pattern" xml:space="preserve">
       <value>Pattern</value>
     </data>
+    <data name="ManualExplorer" xml:space="preserve">
+      <value>Manual Explorer</value>
+    </data>
+    <data name="ExtractManually" xml:space="preserve">
+      <value>Extract manually</value>
+    </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.ru.resx
+++ b/FoliCon/Properties/Langs/Lang.ru.resx
@@ -648,4 +648,10 @@
   <data name="Pattern" xml:space="preserve">
     <value>Шаблон</value>
   </data>
+  <data name="ManualExplorer" xml:space="preserve">
+    <value>Ручной проводник</value>
+  </data>
+  <data name="ExtractManually" xml:space="preserve">
+    <value>Извлечь вручную</value>
+  </data>
 </root>

--- a/FoliCon/ViewModels/MainWindowViewModel.cs
+++ b/FoliCon/ViewModels/MainWindowViewModel.cs
@@ -841,7 +841,6 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
         }
 
         IsMakeEnabled = true;
-        FileUtils.DeleteFoliConTempDeviationDirectory();
     }
 
     private void MakeIcons()
@@ -919,6 +918,5 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
     {
         _tmdbClient?.Dispose();
         GC.SuppressFinalize(this);
-        FileUtils.DeleteFoliConTempDeviationDirectory();
     }
 }

--- a/FoliCon/ViewModels/MainWindowViewModel.cs
+++ b/FoliCon/ViewModels/MainWindowViewModel.cs
@@ -806,7 +806,14 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
 
             try
             {
-                await NetworkUtils.DownloadImageFromUrlAsync(img.RemotePath, img.LocalPath);
+                if (img.RemotePath.IsFile)
+                {
+                    File.Move(img.RemotePath.AbsolutePath, img.LocalPath);
+                }
+                else
+                {
+                    await NetworkUtils.DownloadImageFromUrlAsync(img.RemotePath, img.LocalPath);
+                }
             }
             catch (UnauthorizedAccessException e)
             {
@@ -834,6 +841,7 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
         }
 
         IsMakeEnabled = true;
+        FileUtils.DeleteFoliConTempDeviationDirectory();
     }
 
     private void MakeIcons()
@@ -911,5 +919,6 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
     {
         _tmdbClient?.Dispose();
         GC.SuppressFinalize(this);
+        FileUtils.DeleteFoliConTempDeviationDirectory();
     }
 }

--- a/FoliCon/ViewModels/ManualExplorerViewModel.cs
+++ b/FoliCon/ViewModels/ManualExplorerViewModel.cs
@@ -15,12 +15,13 @@ public class ManualExplorerViewModel : BindableBase, IDialogAware
 		OpenImageCommand = new DelegateCommand<object>(OpenImageMethod);
 	}
 
-	private void PickMethod(object obj)
+	private void PickMethod(object localImagePath)
 	{
-		
+		Logger.Debug("Picking Image {Image}", localImagePath);
+		CloseDialog(ButtonResult.OK, (string)localImagePath);
 	}
 
-	private string _title = LangProvider.GetLang("SearchResult");
+	private string _title = "Manual Explorer";
 	private bool _isBusy;
 	private ObservableCollection<string> _directory;
 	private DArt _dArtObject;
@@ -58,7 +59,22 @@ public class ManualExplorerViewModel : BindableBase, IDialogAware
 	public virtual void OnDialogClosed()
 	{
 		Directory.Clear();
-		
+	}
+	
+	protected virtual void CloseDialog(ButtonResult result, string localPath)
+	{
+		Logger.Info("Close Dialog called with result {Result}, localImagePath {LocalImagePath}", result, localPath);
+		var dialogParams = new DialogParameters()
+		{
+			{"localPath", localPath}
+		};
+
+		RaiseRequestClose(new DialogResult(result, dialogParams));
+	}
+
+	public virtual void RaiseRequestClose(IDialogResult dialogResult)
+	{
+		RequestClose?.Invoke(dialogResult);
 	}
 
 	public virtual void OnDialogOpened(IDialogParameters parameters)

--- a/FoliCon/ViewModels/ManualExplorerViewModel.cs
+++ b/FoliCon/ViewModels/ManualExplorerViewModel.cs
@@ -21,7 +21,7 @@ public class ManualExplorerViewModel : BindableBase, IDialogAware
 		CloseDialog(ButtonResult.OK, (string)localImagePath);
 	}
 
-	private string _title = "Manual Explorer";
+	private string _title = LangProvider.GetLang("ManualExplorer");
 	private bool _isBusy;
 	private ObservableCollection<string> _directory;
 	private DArt _dArtObject;

--- a/FoliCon/ViewModels/ManualExplorerViewModel.cs
+++ b/FoliCon/ViewModels/ManualExplorerViewModel.cs
@@ -1,0 +1,80 @@
+﻿
+using FoliCon.Modules.DeviantArt;
+using NLog;
+
+namespace FoliCon.ViewModels;
+
+public class ManualExplorerViewModel : BindableBase, IDialogAware
+{
+	private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
+	
+	public ManualExplorerViewModel()
+	{
+		Directory = [];
+		PickCommand = new DelegateCommand<object>(PickMethod);
+		OpenImageCommand = new DelegateCommand<object>(OpenImageMethod);
+	}
+
+	private void PickMethod(object obj)
+	{
+		
+	}
+
+	private string _title = LangProvider.GetLang("SearchResult");
+	private bool _isBusy;
+	private ObservableCollection<string> _directory;
+	private DArt _dArtObject;
+        
+	public string Title { get => _title; set => SetProperty(ref _title, value); }
+	public bool IsBusy { get => _isBusy; set => SetProperty(ref _isBusy, value); }
+	public DArt DArtObject { get => _dArtObject; set => SetProperty(ref _dArtObject, value); }
+	public ObservableCollection<string> Directory { get => _directory; set => SetProperty(ref _directory, value); }
+	
+	public DelegateCommand<object> PickCommand { get; set; }
+	public DelegateCommand<object> OpenImageCommand { get; set; }
+	
+	
+	private void OpenImageMethod(object parameter)
+	{
+		Logger.Debug("Opening Image {Image}", parameter);
+		var link = (string)parameter;
+		var browser = new ImageBrowser(link)
+		{
+			ShowTitle = false,
+			IsFullScreen = true
+		};
+		browser.Show();
+	}
+	
+	#region DialogMethods
+
+	public event Action<IDialogResult> RequestClose;
+
+	public virtual bool CanCloseDialog()
+	{
+		return true;
+	}
+
+	public virtual void OnDialogClosed()
+	{
+		Directory.Clear();
+		
+	}
+
+	public virtual void OnDialogOpened(IDialogParameters parameters)
+	{
+		parameters.TryGetValue("DeviationId", out string deviationId);
+		DArtObject = parameters.GetValue<DArt>("dartobject");
+		IsBusy = true;
+		DArtObject.Download(deviationId).ContinueWith(task =>
+		{
+			Logger.Debug("Downloaded Image from Deviation ID {DeviationId}", deviationId);
+			var dArtDownloadResponse = task.Result;
+			dArtDownloadResponse.localDownloadPath.ToDirectoryInfo().GetFiles()
+				.ForEach(info => { Directory.AddOnUI(info.FullName); });
+			IsBusy = false;
+		});
+	}
+
+	#endregion DialogMethods
+}

--- a/FoliCon/ViewModels/ManualExplorerViewModel.cs
+++ b/FoliCon/ViewModels/ManualExplorerViewModel.cs
@@ -64,7 +64,7 @@ public class ManualExplorerViewModel : BindableBase, IDialogAware
 	protected virtual void CloseDialog(ButtonResult result, string localPath)
 	{
 		Logger.Info("Close Dialog called with result {Result}, localImagePath {LocalImagePath}", result, localPath);
-		var dialogParams = new DialogParameters()
+		var dialogParams = new DialogParameters
 		{
 			{"localPath", localPath}
 		};

--- a/FoliCon/ViewModels/ManualExplorerViewModel.cs
+++ b/FoliCon/ViewModels/ManualExplorerViewModel.cs
@@ -86,7 +86,7 @@ public class ManualExplorerViewModel : BindableBase, IDialogAware
 		{
 			Logger.Debug("Downloaded Image from Deviation ID {DeviationId}", deviationId);
 			var dArtDownloadResponse = task.Result;
-			dArtDownloadResponse.localDownloadPath.ToDirectoryInfo().GetFiles()
+			dArtDownloadResponse.LocalDownloadPath.ToDirectoryInfo().GetFiles()
 				.ForEach(info => { Directory.AddOnUI(info.FullName); });
 			IsBusy = false;
 		});

--- a/FoliCon/ViewModels/ProSearchResultViewModel.cs
+++ b/FoliCon/ViewModels/ProSearchResultViewModel.cs
@@ -96,7 +96,11 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
         var deviationId = (string)parameter;
         _dialogService.ShowManualExplorer(deviationId, DArtObject, result =>
         {
-            if (result.Result != ButtonResult.OK) return;
+            if (result.Result != ButtonResult.OK)
+            {
+                return;
+            }
+
             Logger.Debug("Manual Extraction Completed");
             PickMethod(result.Parameters.GetValue<string>("localPath"));
         });

--- a/FoliCon/ViewModels/ProSearchResultViewModel.cs
+++ b/FoliCon/ViewModels/ProSearchResultViewModel.cs
@@ -24,7 +24,8 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
     private List<ImageToDownload> _imgDownloadList;
     private int _index;
     private int _totalPosters;
-
+    private readonly IDialogService _dialogService;
+    
     public event Action<IDialogResult> RequestClose;
 
     private string _folderPath;
@@ -64,7 +65,7 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
     public DelegateCommand SearchAgainCommand { get; set; }
     public DelegateCommand StopSearchCommand { get; set; }
 
-    public ProSearchResultViewModel()
+    public ProSearchResultViewModel(IDialogService dialogService)
     {
         Logger.Debug("ProSearchResultViewModel Constructor");
         ImageUrl = [];
@@ -74,6 +75,7 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
         ExtractManuallyCommand = new DelegateCommand<object>(ExtractManually);
         SkipCommand = new DelegateCommand(SkipMethod);
         SearchAgainCommand = new DelegateCommand(PrepareForSearch);
+        _dialogService = dialogService;
     }
 
     private void OpenImageMethod(object parameter)
@@ -92,9 +94,12 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
     {
         Logger.Debug("Extracting manually from Deviation ID {DeviationId}", parameter);
         var deviationId = (string)parameter;
-        DArtObject.Download(deviationId).ContinueWith(task =>
+        _dialogService.ShowManualExplorer(deviationId, DArtObject, result =>
         {
-            Logger.Debug("Downloaded Image from Deviation ID {DeviationId}", deviationId);
+            if (result.Result == ButtonResult.OK)
+            {
+                Logger.Debug("Manual Extraction Completed");
+            }
         });
     }
     private async void PrepareForSearch()

--- a/FoliCon/ViewModels/ProSearchResultViewModel.cs
+++ b/FoliCon/ViewModels/ProSearchResultViewModel.cs
@@ -60,16 +60,18 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
     public DelegateCommand SkipCommand { get; set; }
     public DelegateCommand<object> PickCommand { get; set; }
     public DelegateCommand<object> OpenImageCommand { get; set; }
+    public DelegateCommand<object> ExtractManuallyCommand { get; set; }
     public DelegateCommand SearchAgainCommand { get; set; }
     public DelegateCommand StopSearchCommand { get; set; }
 
     public ProSearchResultViewModel()
     {
         Logger.Debug("ProSearchResultViewModel Constructor");
-        ImageUrl = new ObservableCollection<DArtImageList>();
+        ImageUrl = [];
         StopSearchCommand = new DelegateCommand(delegate { StopSearch = true; });
         PickCommand = new DelegateCommand<object>(PickMethod);
         OpenImageCommand = new DelegateCommand<object>(OpenImageMethod);
+        ExtractManuallyCommand = new DelegateCommand<object>(ExtractManually);
         SkipCommand = new DelegateCommand(SkipMethod);
         SearchAgainCommand = new DelegateCommand(PrepareForSearch);
     }
@@ -86,6 +88,15 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
         browser.Show();
     }
 
+    private void ExtractManually(object parameter)
+    {
+        Logger.Debug("Extracting manually from Deviation ID {DeviationId}", parameter);
+        var deviationId = (string)parameter;
+        DArtObject.Download(deviationId).ContinueWith(task =>
+        {
+            Logger.Debug("Downloaded Image from Deviation ID {DeviationId}", deviationId);
+        });
+    }
     private async void PrepareForSearch()
     {
         StopSearch = false;
@@ -128,8 +139,7 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
                     }
                     using (var bm = await response.GetBitmap())
                     {
-                        ImageUrl.Add(new DArtImageList(item.Value.Content.Src, ImageUtils.LoadBitmap(bm)));
-                        bm.Dispose();
+                        ImageUrl.Add(new DArtImageList(item.Value.Content.Src, ImageUtils.LoadBitmap(bm), item.Value.Deviationid));
                     }
                     if (_stopSearch)
                     {

--- a/FoliCon/ViewModels/ProSearchResultViewModel.cs
+++ b/FoliCon/ViewModels/ProSearchResultViewModel.cs
@@ -96,10 +96,9 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
         var deviationId = (string)parameter;
         _dialogService.ShowManualExplorer(deviationId, DArtObject, result =>
         {
-            if (result.Result == ButtonResult.OK)
-            {
-                Logger.Debug("Manual Extraction Completed");
-            }
+            if (result.Result != ButtonResult.OK) return;
+            Logger.Debug("Manual Extraction Completed");
+            PickMethod(result.Parameters.GetValue<string>("localPath"));
         });
     }
     private async void PrepareForSearch()

--- a/FoliCon/Views/MainWindow.xaml
+++ b/FoliCon/Views/MainWindow.xaml
@@ -18,7 +18,7 @@
            Icon="/Resources/icons/folicon Icon.ico"
         ui:FolderDragDropHelper.IsFileDragDropEnabled="True"
         ui:FolderDragDropHelper.FileDragDropTarget="{Binding}" AllowDrop="True"
-        d:DataContext="{d:DesignInstance viewModels:MainWindowViewModel}">
+        d:DataContext="{d:DesignInstance viewModels:MainWindowViewModel}" Closed="MainWindow_OnClosed">
 
     <Window.Resources>
         <convertor:BoolToColorConverter x:Key="BoolToColorConverter"/>

--- a/FoliCon/Views/MainWindow.xaml.cs
+++ b/FoliCon/Views/MainWindow.xaml.cs
@@ -81,4 +81,9 @@ public partial class MainWindow
         dataView.SortDescriptions.Add(sd);
         dataView.Refresh();
     }
+
+    private void MainWindow_OnClosed(object sender, EventArgs e)
+    {
+        FileUtils.DeleteFoliConTempDeviationDirectory();
+    }
 }

--- a/FoliCon/Views/ManualExplorer.xaml
+++ b/FoliCon/Views/ManualExplorer.xaml
@@ -3,9 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
              xmlns:hc="https://handyorg.github.io/handycontrol"
-             xmlns:extension="clr-namespace:FoliCon.Modules.Extension"
-             xmlns:langs="clr-namespace:FoliCon.Properties.Langs"
-             xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:ui="clr-namespace:FoliCon.Modules.UI"
@@ -37,13 +34,11 @@
                 <ItemsControl ItemsSource="{Binding Directory}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Image Tag="{Binding}" Height="128" Width="128"
+                            <Image Tag="{Binding}" Height="128" Width="128" Source="{Binding}" Unloaded="FrameworkElement_OnUnloaded"
                                    RenderOptions.BitmapScalingMode="HighQuality" Margin="5, 5, 5, 5">
-                                <Image.Source>
-                                    <BitmapImage UriSource="{Binding}" CacheOption="OnLoad" />
-                                </Image.Source>
                                 <i:Interaction.Behaviors>
-                                    <ui:ClickBehavior CommandParameter="{Binding Path=Tag, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Image}}}" DoubleClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
+                                    <ui:ClickBehavior CommandParameter="{Binding Path=Tag, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Image}}}" 
+                                                      DoubleClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
                                                         AncestorType={x:Type Window}}, Path=DataContext.(viewModels:ManualExplorerViewModel.PickCommand)}" 
                                                       ClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
                                                         AncestorType={x:Type Window}}, Path=DataContext.(viewModels:ManualExplorerViewModel.OpenImageCommand)}"/>

--- a/FoliCon/Views/ManualExplorer.xaml
+++ b/FoliCon/Views/ManualExplorer.xaml
@@ -1,0 +1,63 @@
+﻿<UserControl x:Class="FoliCon.Views.ManualExplorer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:hc="https://handyorg.github.io/handycontrol"
+             xmlns:extension="clr-namespace:FoliCon.Modules.Extension"
+             xmlns:langs="clr-namespace:FoliCon.Properties.Langs"
+             xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ui="clr-namespace:FoliCon.Modules.UI"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             xmlns:viewModels="clr-namespace:FoliCon.ViewModels"
+             prism:ViewModelLocator.AutoWireViewModel="True"
+             d:DataContext="{d:DesignInstance viewModels:ManualExplorerViewModel }">
+    <prism:Dialog.WindowStyle>
+        <Style TargetType="Window">
+            <Setter Property="Height" Value="450" />
+            <Setter Property="Width" Value="900" />
+            <Setter Property="prism:Dialog.WindowStartupLocation" Value="CenterOwner" />
+        </Style>
+    </prism:Dialog.WindowStyle>
+    <hc:BusyIndicator IsBusy="{Binding IsBusy}">
+        <hc:BusyIndicator.BusyContent>
+            <StackPanel>
+                <TextBlock FontWeight="Bold" Text="Extracting..." />
+            </StackPanel>
+        </hc:BusyIndicator.BusyContent>
+        <Grid Margin="12,12,12,12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <hc:ScrollViewer x:Name="ScrollViewer" Grid.Row="0" HorizontalScrollBarVisibility="Disabled"
+                             HorizontalAlignment="Stretch"
+                             VerticalAlignment="Stretch" ScrollChanged="ScrollViewer_ScrollChanged">
+                <ItemsControl ItemsSource="{Binding Directory}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Image Tag="{Binding}" Height="128" Width="128"
+                                   RenderOptions.BitmapScalingMode="HighQuality" Margin="5, 5, 5, 5">
+                                <Image.Source>
+                                    <BitmapImage UriSource="{Binding}" CacheOption="OnLoad" />
+                                </Image.Source>
+                                <i:Interaction.Behaviors>
+                                    <ui:ClickBehavior CommandParameter="{Binding Path=Tag, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Image}}}" DoubleClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
+                                                        AncestorType={x:Type Window}}, Path=DataContext.(viewModels:ManualExplorerViewModel.PickCommand)}" 
+                                                      ClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
+                                                        AncestorType={x:Type Window}}, Path=DataContext.(viewModels:ManualExplorerViewModel.OpenImageCommand)}"/>
+                                </i:Interaction.Behaviors>
+                            </Image>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </hc:ScrollViewer>
+        </Grid>
+    </hc:BusyIndicator>
+</UserControl>

--- a/FoliCon/Views/ManualExplorer.xaml.cs
+++ b/FoliCon/Views/ManualExplorer.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System.Windows.Controls;
+
+namespace FoliCon.Views
+{
+    /// <summary>
+    /// Interaction logic for ManualExplorer
+    /// </summary>
+    public partial class ManualExplorer : UserControl
+    {
+        private bool _autoScroll = true;
+        
+        public ManualExplorer()
+        {
+            InitializeComponent();
+        }
+        
+        private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
+        {
+            if (e.ExtentHeightChange == 0)
+            {
+                
+                _autoScroll = ScrollViewer.VerticalOffset == ScrollViewer.ScrollableHeight;
+            }
+
+
+            if (_autoScroll && e.ExtentHeightChange != 0)
+            {
+                ScrollViewer.ScrollToVerticalOffset(ScrollViewer.ExtentHeight);
+            }
+        }
+    }
+}

--- a/FoliCon/Views/ManualExplorer.xaml.cs
+++ b/FoliCon/Views/ManualExplorer.xaml.cs
@@ -1,32 +1,38 @@
-﻿using System.Windows.Controls;
+﻿
+using Image = System.Windows.Controls.Image;
 
-namespace FoliCon.Views
+namespace FoliCon.Views;
+
+/// <summary>
+/// Interaction logic for ManualExplorer
+/// </summary>
+public partial class ManualExplorer : UserControl
 {
-    /// <summary>
-    /// Interaction logic for ManualExplorer
-    /// </summary>
-    public partial class ManualExplorer : UserControl
+    private bool _autoScroll = true;
+        
+    public ManualExplorer()
     {
-        private bool _autoScroll = true;
+        InitializeComponent();
+    }
         
-        public ManualExplorer()
+    private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        if (e.ExtentHeightChange == 0)
         {
-            InitializeComponent();
-        }
-        
-        private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
-        {
-            if (e.ExtentHeightChange == 0)
-            {
                 
-                _autoScroll = ScrollViewer.VerticalOffset == ScrollViewer.ScrollableHeight;
-            }
-
-
-            if (_autoScroll && e.ExtentHeightChange != 0)
-            {
-                ScrollViewer.ScrollToVerticalOffset(ScrollViewer.ExtentHeight);
-            }
+            _autoScroll = ScrollViewer.VerticalOffset == ScrollViewer.ScrollableHeight;
         }
+
+
+        if (_autoScroll && e.ExtentHeightChange != 0)
+        {
+            ScrollViewer.ScrollToVerticalOffset(ScrollViewer.ExtentHeight);
+        }
+    }
+
+    private void FrameworkElement_OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        var image = (Image)sender;
+        image.Source = null;
     }
 }

--- a/FoliCon/Views/ProSearchResult.xaml
+++ b/FoliCon/Views/ProSearchResult.xaml
@@ -13,6 +13,9 @@
              mc:Ignorable="d"
              prism:ViewModelLocator.AutoWireViewModel="True"
              d:DataContext="{d:DesignInstance viewModels:ProSearchResultViewModel }">
+    <UserControl.Resources>
+        <hc:BindingProxy x:Key="Proxy" Value="{Binding}" />
+    </UserControl.Resources>
     <prism:Dialog.WindowStyle>
         <Style TargetType="Window">
             <Setter Property="Height" Value="450" />
@@ -76,6 +79,15 @@
                                                            ClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
                                                         AncestorType={x:Type Window}}, Path=DataContext.(viewModels:ProSearchResultViewModel.OpenImageCommand)}"/>
                                 </i:Interaction.Behaviors>
+                                <Image.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem
+                                            Header="Extract Manually"
+                                            Command="{Binding Value.OpenImageCommand,
+                                             Source={StaticResource Proxy}}" 
+                                            CommandParameter="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ContextMenu}}" />
+                                    </ContextMenu>
+                                </Image.ContextMenu>
                             </Image>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>

--- a/FoliCon/Views/ProSearchResult.xaml
+++ b/FoliCon/Views/ProSearchResult.xaml
@@ -82,7 +82,7 @@
                                 <Image.ContextMenu>
                                     <ContextMenu>
                                         <MenuItem
-                                            Header="Extract Manually"
+                                            Header="{extension:Lang Key={x:Static langs:LangKeys.ExtractManually}}"
                                             Command="{Binding Value.ExtractManuallyCommand,
                                              Source={StaticResource Proxy}}" 
                                             CommandParameter="{Binding PlacementTarget.Tag.DeviationId, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ContextMenu}}" />

--- a/FoliCon/Views/ProSearchResult.xaml
+++ b/FoliCon/Views/ProSearchResult.xaml
@@ -71,10 +71,10 @@
                 <ItemsControl ItemsSource="{Binding ImageUrl}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Image Source="{Binding Image}" Tag="{Binding Url}" Height="128" Width="128"
+                            <Image Source="{Binding Image}" Tag="{Binding }" Height="128" Width="128"
                                    RenderOptions.BitmapScalingMode="HighQuality" Margin="5, 5, 5, 5">
                                 <i:Interaction.Behaviors>
-                                    <ui:ClickBehavior CommandParameter="{Binding Path=Tag, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Image}}}" DoubleClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
+                                    <ui:ClickBehavior CommandParameter="{Binding Path=Tag.Url, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Image}}}" DoubleClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
                                                         AncestorType={x:Type Window}}, Path=DataContext.(viewModels:ProSearchResultViewModel.PickCommand)}" 
                                                            ClickCommand="{Binding RelativeSource={RelativeSource FindAncestor,
                                                         AncestorType={x:Type Window}}, Path=DataContext.(viewModels:ProSearchResultViewModel.OpenImageCommand)}"/>
@@ -83,9 +83,9 @@
                                     <ContextMenu>
                                         <MenuItem
                                             Header="Extract Manually"
-                                            Command="{Binding Value.OpenImageCommand,
+                                            Command="{Binding Value.ExtractManuallyCommand,
                                              Source={StaticResource Proxy}}" 
-                                            CommandParameter="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ContextMenu}}" />
+                                            CommandParameter="{Binding PlacementTarget.Tag.DeviationId, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ContextMenu}}" />
                                     </ContextMenu>
                                 </Image.ContextMenu>
                             </Image>


### PR DESCRIPTION
Added ManualExplorer view to the FoliCon application, enabling manual extraction of images in professional mode. The ManualExplorer view is designed to display images from the extracted deviation and allows users to pick/view them. Additionally, a ViewModel was created for this view to handle its associated functionalities. The DialogServiceExtensions class is also updated to provide dialog services for the new view.

Closes #202 