### PR TITLE
Fix: Incorrect total folder count when subfolder processing is enabled and Incorrect processed count in a case where skipAmbigous was true and there were multiple results

### DIFF
--- a/FoliCon/ViewModels/MainWindowViewModel.cs
+++ b/FoliCon/ViewModels/MainWindowViewModel.cs
@@ -335,7 +335,7 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
                 return;
             }
 
-            if (Fnames.Count != 0)
+            if (Fnames.Count != 0 || Services.Settings.SubfolderProcessingEnabled)
             {
                 if (NetworkUtils.IsNetworkAvailable())
                 {
@@ -349,7 +349,6 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
 
                     StatusBarProperties.ResetData();
                     FinalListViewData.Data.Clear();
-                    StatusBarProperties.TotalFolders = Fnames.Count;
                     PrepareForSearch();
                     if (IconMode == "Poster")
                     {
@@ -412,7 +411,7 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
             {
                 continue;
             }
-            
+            StatusBarProperties.TotalFolders+= subfolderNames.Count;
             foreach (var itemTitle in subfolderNames)
             {
                 var fullFolderPath = $@"{folderPath}\{itemTitle}";
@@ -577,6 +576,7 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
         var taskCompletionSource = new TaskCompletionSource<(bool dialogResult, bool skipAll)>();
         if (!IsPosterWindowShown && IsSkipAmbiguous)
         {
+            taskCompletionSource.SetResult((false, false));
             return await taskCompletionSource.Task;
         }
 
@@ -616,6 +616,7 @@ public class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDisposabl
             {
                 continue;
             }
+            StatusBarProperties.TotalFolders+= subfolderNames.Count;
             StatusBarProperties.AppStatus = "Searching";
             _dialogService.ShowProSearchResult(folderPath, subfolderNames, _pickedListDataTable, _imgDownloadList,
                 _dArtObject, _ => { });


### PR DESCRIPTION
Properly update the total folder count by not only considering parent folders but also adding the count of subfolders found during the search process. It also resolves an issue where a potentially incorrect folder processed count was returned when the poster window was not shown and 'Skip Ambiguous' was checked.