### PR TITLE
Change approch to filter files extract by "gallery extraction" feature

### DIFF
--- a/FoliCon/Modules/Extension/StreamExtension.cs
+++ b/FoliCon/Modules/Extension/StreamExtension.cs
@@ -31,19 +31,13 @@ public static class StreamExtensions
     {
         using var reader = ArchiveFactory.Open(archiveStream, ReaderOptions);
         var pngAndIcoEntries = reader.Entries.Where(entry =>
-            (!entry.IsDirectory && !IsUnwantedDirectoryOrFileType(entry)) && FileUtils.IsPngOrIco(entry.Key));
+            !IsUnwantedDirectoryOrFileType(entry) && FileUtils.IsPngOrIco(entry.Key)).ToList();
         
-        var pngAndIcoFiles = pngAndIcoEntries.GroupBy(entry => Path.GetFileNameWithoutExtension(entry.Key))
-            .Select(group =>
-                group.Any(entry => Path.GetExtension(entry.Key) == ".png")
-                    ? group.First(entry => Path.GetExtension(entry.Key) == ".png")
-                    : group.First())
-            .ToArray();
         
-        var totalCount = pngAndIcoFiles.Length;
+        var totalCount = pngAndIcoEntries.Count;
         var extractionProgress = new ProgressInfo(0, totalCount, LangProvider.Instance.Extracting);
         progressCallback.Report(extractionProgress);
-        foreach (var entry in pngAndIcoFiles)
+        foreach (var entry in pngAndIcoEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
             entry.WriteToDirectory(targetPath, ExtractionSettings);

--- a/FoliCon/ViewModels/ManualExplorerViewModel.cs
+++ b/FoliCon/ViewModels/ManualExplorerViewModel.cs
@@ -108,11 +108,24 @@ public class ManualExplorerViewModel : BindableBase, IDialogAware
 		{
 			Logger.Debug("User cancelled manual extraction");
 			
-		} 
+		}
 
-		DArtDownloadResponse.LocalDownloadPath?.ToDirectoryInfo()
-			.GetFiles()
-			.ForEach(fileInfo => Directory.AddOnUI(fileInfo.FullName));
+		var extractedFiles = DArtDownloadResponse.LocalDownloadPath?.ToDirectoryInfo()
+			.GetFiles();
+		Logger.Trace("Total Files Extracted {TotalFiles}", extractedFiles?.Length);
+		if (extractedFiles?.Length > 0)
+		{
+			var pngOrAvailableFile = extractedFiles
+				.GroupBy(entry => Path.GetFileNameWithoutExtension(entry.Name))
+				.Select(group =>
+				{
+					var pngFile = group.FirstOrDefault(entry => Path.GetExtension(entry.Name) == ".png");
+					return pngFile ?? group.First();
+				}).ToList();
+			
+			Logger.Trace("Total extracted files after filtering {TotalFiles}", pngOrAvailableFile.Count);
+			pngOrAvailableFile.ForEach(entry => Directory.AddOnUI(entry.FullName));
+		}
 
 		IsBusy = false;
 		_cts.Dispose();


### PR DESCRIPTION
Instead of filtering the compressed stream, extract all files first, then apply image filtering during display. If identical images are found in different formats (e.g., ico and png), only the png version is shown.

The progress bar will show count for all files as all are being downloaded and extracted, however in case of duplicate, png file will be prioritized so user may see less files then displayed on progress bar 