### PR TITLE
Add Crowdin integration for localization and update README with translation instructions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,30 @@
+name: Crowdin Integration
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'FoliCon/Properties/Langs/Lang.resx'
+  workflow_dispatch:
+
+jobs:
+  sync-with-crowdin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Crowdin Action
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          download_translations: true
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'Automated synchronization with translations from Crowdin'
+          pull_request_labels: 'crowdin, i18n, translations'
+          localization_branch_name: l10n_master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,38 @@ To compile this Source you need to Create "AppConfig.json" file with structure g
   "IgdbClientSecret": "Your_Client_Secret_API_here"
 }
 ```
+
+## Localization
+FoliCon supports multiple languages through Crowdin integration. The application is currently available in English, Spanish, Arabic, Russian, Hindi, and Portuguese. 
+
+### Help with Translations
+We welcome contributions to translate FoliCon into more languages:
+
+1. Visit our [Crowdin project](https://crowdin.com/project/folicon)
+2. Sign up or log in to Crowdin
+3. Select the language you want to help translate
+4. Start translating strings
+
+### For Developers
+If you're working on the source code and want to manage translations:
+
+1. Set up your Crowdin API credentials
+   ```
+   $env:CROWDIN_PROJECT_ID = "your_project_id"
+   $env:CROWDIN_API_TOKEN = "your_api_token"
+   ```
+
+2. Use the provided PowerShell script for common operations:
+   ```
+   # Upload source files to Crowdin
+   .\crowdin-sync.ps1 -Action upload-sources
+
+   # Download latest translations
+   .\crowdin-sync.ps1 -Action download
+   ```
+
+3. GitHub Actions automatically synchronizes translations when changes are pushed to the main branch.
+
 ### Prerequisites (these are for compiling the source, to only use the application, you can download latest release)
 A TMDB API [Get it](https://www.themoviedb.org/settings/api)
 
@@ -70,6 +102,7 @@ DeviantArt API [Get it](https://www.deviantart.com/developers/register)
 * [Ookii.Dialogs.Wpf](https://github.com/caioproiete/ookii-dialogs-wpf) - For File Dialogs
 * [NLog](https://nlog-project.org/) - For Logging
 * [Sentry](https://sentry.io) -  For Error Tracking
+* [Crowdin](https://crowdin.com) - For localization management
 
 ## Authors
 

--- a/crowdin-sync.ps1
+++ b/crowdin-sync.ps1
@@ -1,0 +1,84 @@
+param (
+    [Parameter(Mandatory=$false)]
+    [string]$Action = "help",
+    
+    [Parameter(Mandatory=$false)]
+    [string]$ProjectId = $env:CROWDIN_PROJECT_ID,
+    
+    [Parameter(Mandatory=$false)]
+    [string]$ApiToken = $env:CROWDIN_API_TOKEN
+)
+
+$ErrorActionPreference = "Stop"
+
+function EnsureCrowdinCliIsInstalled {
+    try {
+        $crowdinVersion = crowdin --version
+        Write-Host "Crowdin CLI is installed: $crowdinVersion"
+    } catch {
+        Write-Host "Installing Crowdin CLI..."
+        npm install -g @crowdin/cli
+    }
+}
+
+function SetEnvironmentVariables {
+    if (-not $ProjectId) {
+        $ProjectId = Read-Host "Enter your Crowdin Project ID"
+    }
+    
+    if (-not $ApiToken) {
+        $ApiToken = Read-Host "Enter your Crowdin API Token"
+    }
+    
+    $env:CROWDIN_PROJECT_ID = $ProjectId
+    $env:CROWDIN_API_TOKEN = $ApiToken
+    
+    Write-Host "Environment variables set for this session"
+}
+
+function UploadSources {
+    Write-Host "Uploading source files to Crowdin..."
+    crowdin upload sources
+}
+
+function UploadTranslations {
+    Write-Host "Uploading existing translations to Crowdin..."
+    crowdin upload translations
+}
+
+function DownloadTranslations {
+    Write-Host "Downloading translations from Crowdin..."
+    crowdin download
+}
+
+function ShowHelp {
+    Write-Host @"
+Crowdin Sync Script for FoliCon
+
+Usage:
+    .\crowdin-sync.ps1 -Action <action> [-ProjectId <project_id>] [-ApiToken <api_token>]
+
+Actions:
+    upload-sources     - Upload source files to Crowdin
+    upload-translations - Upload existing translations to Crowdin
+    download           - Download translations from Crowdin
+    help               - Show this help message
+
+If ProjectId and ApiToken are not provided, the script will use environment variables
+CROWDIN_PROJECT_ID and CROWDIN_API_TOKEN or prompt for them.
+
+Example:
+    .\crowdin-sync.ps1 -Action download
+"@
+}
+
+# Main execution flow
+EnsureCrowdinCliIsInstalled
+SetEnvironmentVariables
+
+switch ($Action.ToLower()) {
+    "upload-sources" { UploadSources }
+    "upload-translations" { UploadTranslations }
+    "download" { DownloadTranslations }
+    default { ShowHelp }
+}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,10 @@
 files:
   - source: /FoliCon/Properties/Langs/Lang.resx
     translation: /FoliCon/Properties/Langs/Lang.%two_letters_code%.resx
+    update_option: update_as_unapproved
+
+"preserve_hierarchy": true
+
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_API_TOKEN
+base_path: .


### PR DESCRIPTION
Introduce Crowdin integration for managing localization, enabling automated synchronization of translations. Update README to include instructions for contributing translations and managing Crowdin API credentials.