### PR TITLE
Fix build errors and adapt codebase for dependency upgrades

### DIFF
--- a/FoliCon/Models/Usings.cs
+++ b/FoliCon/Models/Usings.cs
@@ -41,7 +41,7 @@ global using Ookii.Dialogs.Wpf;
 
 global using Prism.Commands;
 global using Prism.Mvvm;
-global using Prism.Services.Dialogs;
+global using Prism.Dialogs;
 
 global using System;
 global using System.Collections.Generic;

--- a/FoliCon/Modules/Extension/StreamExtension.cs
+++ b/FoliCon/Modules/Extension/StreamExtension.cs
@@ -8,8 +8,8 @@ namespace FoliCon.Modules.Extension;
 [Localizable(false)]
 public static class StreamExtensions
 {
-    private static readonly ReaderOptions ReaderOptions = new() { ArchiveEncoding = 
-        new ArchiveEncoding(Encoding.GetEncoding("IBM437"), Encoding.GetEncoding("IBM437")) };
+    private static readonly ReaderOptions ReaderOptions = new() { ArchiveEncoding =
+        new ArchiveEncoding { Default = Encoding.GetEncoding("IBM437"), Forced = Encoding.GetEncoding("IBM437") } };
     
     private static readonly ExtractionOptions ExtractionSettings = new()
     {
@@ -28,7 +28,7 @@ public static class StreamExtensions
         CancellationToken cancellationToken,
         IProgress<ProgressBarData> progressCallback)
     {
-        using var reader = ArchiveFactory.Open(archiveStream, ReaderOptions);
+        using var reader = ArchiveFactory.OpenArchive(archiveStream, ReaderOptions);
         var pngAndIcoEntries = reader.Entries.Where(IsValidFile).ToList();
         
         

--- a/FoliCon/Modules/UI/HandyWindow.cs
+++ b/FoliCon/Modules/UI/HandyWindow.cs
@@ -39,14 +39,15 @@ public class HandyWindow : Window, IDialogWindow
 
     private void HandleDataContextChanged()
     {
-        if (DataContext is not IDialogAware dialogAware)
+        if (DataContext is not IDialogAware)
         {
             return;
         }
 
-        // Set title and subscribe to updates
-        Title = dialogAware.Title;
-        if(dialogAware is INotifyPropertyChanged notifyPropertyChanged)
+        // Set title and subscribe to updates. Prism 9 removed IDialogAware.Title,
+        // so the title is read from the ViewModel's own Title property.
+        UpdateTitle(DataContext);
+        if(DataContext is INotifyPropertyChanged notifyPropertyChanged)
         {
             notifyPropertyChanged.PropertyChanged += DialogAwareOnPropertyChanged;
         }
@@ -55,9 +56,17 @@ public class HandyWindow : Window, IDialogWindow
     private void DialogAwareOnPropertyChanged(object sender, PropertyChangedEventArgs args)
     {
         // Only update when the 'Title' property changes
-        if(args.PropertyName == nameof(IDialogAware.Title) && sender is IDialogAware dialogAware)
+        if(args.PropertyName == "Title")
         {
-            Title = dialogAware.Title;
+            UpdateTitle(sender);
+        }
+    }
+
+    private void UpdateTitle(object dataContext)
+    {
+        if (dataContext?.GetType().GetProperty("Title")?.GetValue(dataContext) is string title)
+        {
+            Title = title;
         }
     }
 }

--- a/FoliCon/Modules/utils/FileUtils.cs
+++ b/FoliCon/Modules/utils/FileUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Security.AccessControl;
 using System.Security.Principal;
+using Vanara.InteropServices;
 
 namespace FoliCon.Modules.utils;
 
@@ -480,7 +481,7 @@ public static class FileUtils
             var folderSettings = new SHFOLDERCUSTOMSETTINGS
             {
                 dwMask = FOLDERCUSTOMSETTINGSMASK.FCSM_ICONFILE,
-                pszIconFile = icoFile,
+                pszIconFile = new StrPtrAuto(icoFile),
                 dwSize = (uint)Marshal.SizeOf(typeof(SHFOLDERCUSTOMSETTINGS)),
                 cchIconFile = 0
             };

--- a/FoliCon/ViewModels/AboutBoxViewModel.cs
+++ b/FoliCon/ViewModels/AboutBoxViewModel.cs
@@ -35,7 +35,7 @@ public class AboutBoxViewModel : BindableBase, IDialogAware
 
     #region DialogMethods
 
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
 
     protected virtual void CloseDialog(string parameter)
     {
@@ -46,12 +46,7 @@ public class AboutBoxViewModel : BindableBase, IDialogAware
             _ => ButtonResult.None
         };
 
-        RaiseRequestClose(new DialogResult(result));
-    }
-
-    public virtual void RaiseRequestClose(IDialogResult dialogResult)
-    {
-        RequestClose?.Invoke(dialogResult);
+        RequestClose.Invoke(result);
     }
 
     public virtual bool CanCloseDialog()

--- a/FoliCon/ViewModels/ApiConfigurationViewModel.cs
+++ b/FoliCon/ViewModels/ApiConfigurationViewModel.cs
@@ -43,7 +43,7 @@ public class ApiConfigurationViewModel : BindableBase, IDialogAware
 
     #region DialogMethods
 
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
 
     protected virtual void CloseDialog(string parameter)
     {
@@ -54,12 +54,7 @@ public class ApiConfigurationViewModel : BindableBase, IDialogAware
             _ => ButtonResult.None
         };
 
-        RaiseRequestClose(new DialogResult(result));
-    }
-
-    public virtual void RaiseRequestClose(IDialogResult dialogResult)
-    {
-        RequestClose?.Invoke(dialogResult);
+        RequestClose.Invoke(result);
     }
 
     public virtual bool CanCloseDialog()

--- a/FoliCon/ViewModels/CustomIconControlViewModel.cs
+++ b/FoliCon/ViewModels/CustomIconControlViewModel.cs
@@ -188,7 +188,7 @@ public class CustomIconControlViewModel : BindableBase, IDialogAware, IFileDragD
 
     #region DialogMethods
 
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
 
     protected virtual void CloseDialog(string parameter)
     {
@@ -199,11 +199,8 @@ public class CustomIconControlViewModel : BindableBase, IDialogAware, IFileDragD
             _ => ButtonResult.None
         };
 
-        RaiseRequestClose(new DialogResult(result));
+        RequestClose.Invoke(result);
     }
-
-    protected virtual void RaiseRequestClose(IDialogResult dialogResult) =>
-        RequestClose?.Invoke(dialogResult);
 
     public virtual bool CanCloseDialog() => true;
 

--- a/FoliCon/ViewModels/DialogControlViewModel.cs
+++ b/FoliCon/ViewModels/DialogControlViewModel.cs
@@ -24,7 +24,7 @@ public class DialogControlViewModel : BindableBase, IDialogAware
         private set => SetProperty(ref _title, value);
     }
 
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
 
     protected virtual void CloseDialog(string parameter)
     {
@@ -36,12 +36,7 @@ public class DialogControlViewModel : BindableBase, IDialogAware
             _ => ButtonResult.None
         };
 
-        RaiseRequestClose(new DialogResult(result));
-    }
-
-    protected virtual void RaiseRequestClose(IDialogResult dialogResult)
-    {
-        RequestClose?.Invoke(dialogResult);
+        RequestClose.Invoke(result);
     }
 
     public virtual bool CanCloseDialog()

--- a/FoliCon/ViewModels/ManualExplorerViewModel.cs
+++ b/FoliCon/ViewModels/ManualExplorerViewModel.cs
@@ -46,7 +46,7 @@ public class ManualExplorerViewModel : BindableBase, IDialogAware
 
 	#region DialogMethods
 
-	public event Action<IDialogResult> RequestClose;
+	public DialogCloseListener RequestClose { get; }
 
 	public virtual bool CanCloseDialog()
 	{
@@ -66,12 +66,7 @@ public class ManualExplorerViewModel : BindableBase, IDialogAware
 			{"localPath", localPath}
 		};
 
-		RaiseRequestClose(new DialogResult(result, dialogParams));
-	}
-
-	protected virtual void RaiseRequestClose(IDialogResult dialogResult)
-	{
-		RequestClose?.Invoke(dialogResult);
+		RequestClose.Invoke(dialogParams, result);
 	}
 
 	public virtual async void OnDialogOpened(IDialogParameters parameters)

--- a/FoliCon/ViewModels/PosterPickerViewModel.cs
+++ b/FoliCon/ViewModels/PosterPickerViewModel.cs
@@ -14,7 +14,7 @@ public class PosterPickerViewModel : BindableBase, IDialogAware
     private int _index;
     private string _busyContent = Lang.LoadingPosters;
     private bool _isBusy;
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
     private ResultResponse _result;
     private int _totalPosters;
     private bool _isPickedById;
@@ -66,12 +66,7 @@ public class PosterPickerViewModel : BindableBase, IDialogAware
             _ => ButtonResult.None
         };
 
-        RaiseRequestClose(new DialogResult(result));
-    }
-
-    protected virtual void RaiseRequestClose(IDialogResult dialogResult)
-    {
-        RequestClose?.Invoke(dialogResult);
+        RequestClose.Invoke(result);
     }
 
     public virtual bool CanCloseDialog()

--- a/FoliCon/ViewModels/PreviewerViewModel.cs
+++ b/FoliCon/ViewModels/PreviewerViewModel.cs
@@ -94,7 +94,7 @@
         
         
         #region DialogMethods
-        public event Action<IDialogResult> RequestClose;
+        public DialogCloseListener RequestClose { get; }
         protected virtual void CloseDialog(string parameter)
         {
             Logger.Info("CloseDialog called with parameter {Parameter}", parameter);
@@ -105,11 +105,8 @@
                 _ => ButtonResult.None
             };
 
-            RaiseRequestClose(new DialogResult(result));
+            RequestClose.Invoke(result);
         }
-
-        public virtual void RaiseRequestClose(IDialogResult dialogResult) =>
-            RequestClose?.Invoke(dialogResult);
 
         public virtual bool CanCloseDialog() => true;
 

--- a/FoliCon/ViewModels/ProSearchResultViewModel.cs
+++ b/FoliCon/ViewModels/ProSearchResultViewModel.cs
@@ -1,6 +1,4 @@
-﻿using ImTools;
-
-namespace FoliCon.ViewModels;
+﻿namespace FoliCon.ViewModels;
 
 [Localizable(false)]
 public class ProSearchResultViewModel : BindableBase, IDialogAware
@@ -21,7 +19,7 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
     private readonly IDialogService _dialogService;
     private bool _subfolderProcessingEnabled = Services.Settings.SubfolderProcessingEnabled;
     
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
 
     private string _folderPath;
     private bool _isSearchFocused;
@@ -166,7 +164,7 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
 
     private static bool HasNoResults(DArtBrowseResult searchResult)
     {
-        return searchResult.Results.IsNullOrEmpty();
+        return searchResult.Results is null or { Length: 0 };
     }
 
     private void ProcessNoResults(string query, int offset)
@@ -289,12 +287,7 @@ public class ProSearchResultViewModel : BindableBase, IDialogAware
             _ => ButtonResult.None
         };
 
-        RaiseRequestClose(new DialogResult(result));
-    }
-
-    protected virtual void RaiseRequestClose(IDialogResult dialogResult)
-    {
-        RequestClose?.Invoke(dialogResult);
+        RequestClose.Invoke(result);
     }
 
     public virtual bool CanCloseDialog()

--- a/FoliCon/ViewModels/SearchResultViewModel.cs
+++ b/FoliCon/ViewModels/SearchResultViewModel.cs
@@ -25,7 +25,7 @@ public class SearchResultViewModel : BindableBase, IDialogAware
     private bool _isSearchFocused;
     private bool _isPickedById;
     private bool _subfolderProcessingEnabled = Services.Settings.SubfolderProcessingEnabled;
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
 
     private Tmdb _tmdbObject;
     private IgdbClass _igdbObject;
@@ -163,12 +163,7 @@ public class SearchResultViewModel : BindableBase, IDialogAware
         {
             { "skipAll", skipAll }
         };
-        RaiseRequestClose(new DialogResult(result, parameters));
-    }
-
-    protected virtual void RaiseRequestClose(IDialogResult dialogResult)
-    {
-        RequestClose?.Invoke(dialogResult);
+        RequestClose.Invoke(parameters, result);
     }
 
     public virtual bool CanCloseDialog()

--- a/FoliCon/ViewModels/SubfolderProcessingViewModel.cs
+++ b/FoliCon/ViewModels/SubfolderProcessingViewModel.cs
@@ -74,7 +74,7 @@ public class SubfolderProcessingViewModel : BindableBase, IDialogAware
     
     #region DialogMethods
 
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
 
     public virtual bool CanCloseDialog()
     {

--- a/FoliCon/ViewModels/posterIconConfigViewModel.cs
+++ b/FoliCon/ViewModels/posterIconConfigViewModel.cs
@@ -33,7 +33,7 @@ public class PosterIconConfigViewModel : BindableBase, IDialogAware
 
     #region DialogMethods
 
-    public event Action<IDialogResult> RequestClose;
+    public DialogCloseListener RequestClose { get; }
 
     protected virtual void CloseDialog(string parameter)
     {
@@ -45,11 +45,8 @@ public class PosterIconConfigViewModel : BindableBase, IDialogAware
             _ => ButtonResult.None
         };
 
-        RaiseRequestClose(new DialogResult(result));
+        RequestClose.Invoke(result);
     }
-
-    public virtual void RaiseRequestClose(IDialogResult dialogResult) =>
-        RequestClose?.Invoke(dialogResult);
 
     public virtual bool CanCloseDialog() => true;
 

--- a/FoliCon/Views/HtmlBox.xaml.cs
+++ b/FoliCon/Views/HtmlBox.xaml.cs
@@ -17,6 +17,13 @@ public partial class HtmlBox
     private const string DarkGray = "#1C1C1C";
     private const string White = "#FFFFFF";
 
+    // Serve the player HTML from a real https origin instead of NavigateToString.
+    // NavigateToString gives the document a null origin, so the YouTube iframe sends
+    // no Referer/origin and the player fails with "Error 153" (configuration error).
+    private const string VirtualHostUrl = "https://folicon.local/";
+    private bool _webResourceHandlerRegistered;
+    private string _currentContent = string.Empty;
+
     // Serialize and share WebView2 environment creation across controls
     private static readonly SemaphoreSlim EnvLock = new(1, 1);
     private static Task<CoreWebView2Environment>? _sharedEnvTask;
@@ -169,11 +176,15 @@ public partial class HtmlBox
                 {
                     Browser.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
                     Browser.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+                    RegisterVirtualHostHandler();
                 }
             }
 
-            // Navigate after initialization (or if already initialized)
-            Browser.CoreWebView2?.NavigateToString(content);
+            // Navigate after initialization (or if already initialized).
+            // Serving via the virtual host (instead of NavigateToString) gives the page a
+            // real origin so the embedded YouTube player receives a valid Referer.
+            _currentContent = content;
+            Browser.CoreWebView2?.Navigate(VirtualHostUrl);
         }
         catch (ObjectDisposedException)
         {
@@ -183,6 +194,34 @@ public partial class HtmlBox
         {
             _initLock.Release();
         }
+    }
+
+    // Intercept requests to the virtual host and serve the current player HTML from memory.
+    // This gives the document a real https origin (https://folicon.local) so the YouTube
+    // iframe can send a valid Referer/origin, avoiding "Error 153".
+    private void RegisterVirtualHostHandler()
+    {
+        if (_webResourceHandlerRegistered || Browser.CoreWebView2 == null)
+        {
+            return;
+        }
+
+        Browser.CoreWebView2.AddWebResourceRequestedFilter($"{VirtualHostUrl}*",
+            CoreWebView2WebResourceContext.Document);
+        Browser.CoreWebView2.WebResourceRequested += OnWebResourceRequested;
+        _webResourceHandlerRegistered = true;
+    }
+
+    private void OnWebResourceRequested(object? sender, CoreWebView2WebResourceRequestedEventArgs e)
+    {
+        if (Browser.CoreWebView2 == null)
+        {
+            return;
+        }
+
+        var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(_currentContent));
+        e.Response = Browser.CoreWebView2.Environment.CreateWebResourceResponse(
+            stream, 200, "OK", "Content-Type: text/html; charset=utf-8");
     }
 
     // Create or reuse a shared environment with a dedicated, stable user data folder
@@ -352,8 +391,9 @@ public partial class HtmlBox
                                                             </style>
                                                         </head>
                                                         <body style="background-color: {1}">
-                                                            <iframe id='video' allow='autoplay; fullscreen; clipboard-write; encrypted-media; picture-in-picture' allowfullscreen
-                                                                src='{2}?hl={0}'
+                                                            <iframe id='video' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen' allowfullscreen
+                                                                referrerpolicy="strict-origin-when-cross-origin"
+                                                                src='{2}?hl={0}&origin=https://folicon.local'
                                                                 style="visibility:hidden;" onload="this.style.visibility='visible';">
                                                             </iframe>
                                                             <script src='https://code.jquery.com/jquery-latest.min.js' type='text/javascript'></script>


### PR DESCRIPTION
This pull request introduces several important updates across the codebase to improve compatibility with Prism 9, refactor dialog handling, and address technical debt. The most significant changes are grouped below.

**Prism 9 migration and dialog handling refactor:**

* Replaced usage of `Prism.Services.Dialogs` with `Prism.Dialogs` in global usings to align with Prism 9 updates.
* Removed references to the obsolete `IDialogAware.Title` property (removed in Prism 9). Updated the `HandyWindow` logic to read the `Title` property directly from the ViewModel via reflection, ensuring window titles update correctly. 

**WebView2/YouTube embedding improvement:**

* Changed the way HTML content is served to WebView2 in `HtmlBox.xaml.cs`: introduced a virtual host (`https://folicon.local/`) and registered a resource handler, so the embedded YouTube player receives a valid Referer and origin, fixing playback errors. 

**Technical debt and minor improvements:**

* Updated the `StreamExtensions` class to use `ArchiveFactory.OpenArchive` and adjusted `ReaderOptions` construction for clarity and compatibility.
* Fixed type usage in `SetFolderIcon` by wrapping the icon file path in a `StrPtrAuto` for interop correctness.
* Removed an unused `using` directive from `ProSearchResultViewModel.cs` and simplified a null/empty check for results.