### PR TITLE
feature/cicd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - refactor
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   build:
     name: Build and analyze

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -7,6 +7,10 @@ on:
       - 'FoliCon/Properties/Langs/Lang.resx'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sync-with-crowdin:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - "v*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   version:
     name: Determine version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    name: Determine version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        id: set-version-tag
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump minor version
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        id: set-version-dispatch
+        shell: pwsh
+        run: |
+          [xml]$csproj = Get-Content FoliCon/FoliCon.csproj
+          $current = $csproj.Project.PropertyGroup.Version
+          $parts = $current.Split('.')
+          $newVersion = "$($parts[0]).$([int]$parts[1] + 1).0"
+          echo "version=$newVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Export version
+        id: set-version
+        run: |
+          VERSION="${{ steps.set-version-tag.outputs.version || steps.set-version-dispatch.outputs.version }}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish FoliCon
+    needs: version
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - profile: "Self contained x64"
+            artifact: FoliCon-win-x64-self-contained
+            zip: FoliCon-win-x64-self-contained.zip
+          - profile: "64 dependent"
+            artifact: FoliCon-win-x64-framework-dependent
+            zip: FoliCon-win-x64-framework-dependent.zip
+          - profile: "32 dependent"
+            artifact: FoliCon-win-x86-framework-dependent
+            zip: FoliCon-win-x86-framework-dependent.zip
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Set version
+        shell: pwsh
+        run: |
+          $version = "${{ needs.version.outputs.version }}"
+          $csproj = Get-Content FoliCon/FoliCon.csproj -Raw
+          $csproj = $csproj -replace '<Version>.*?</Version>', "<Version>$version</Version>"
+          $csproj = $csproj -replace '<PackageVersion>.*?</PackageVersion>', "<PackageVersion>$version</PackageVersion>"
+          $csproj = $csproj -replace '<AssemblyVersion>.*?</AssemblyVersion>', "<AssemblyVersion>$version</AssemblyVersion>"
+          Set-Content FoliCon/FoliCon.csproj $csproj
+
+      - name: Publish (${{ matrix.profile }})
+        run: >
+          dotnet publish FoliCon/FoliCon.csproj
+          -p:PublishProfile="${{ matrix.profile }}"
+          --configuration Release
+
+      - name: Zip output
+        shell: pwsh
+        run: |
+          $publishDir = "FoliCon/bin/Release/net9.0-windows/publish"
+          $subDir = if ("${{ matrix.profile }}" -eq "Self contained x64") { "frame64" }
+                    elseif ("${{ matrix.profile }}" -eq "64 dependent") { "64Dependant" }
+                    else { "32 dependent" }
+          Compress-Archive -Path "$publishDir/$subDir/*" -DestinationPath "${{ matrix.zip }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.zip }}
+          retention-days: 1
+
+  release:
+    name: Create GitHub Release
+    needs: [version, publish]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "FoliCon v${{ needs.version.outputs.version }}"
+          generate_release_notes: true
+          files: artifacts/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,19 +45,6 @@ jobs:
     name: Publish FoliCon
     needs: version
     runs-on: windows-latest
-    strategy:
-      matrix:
-        include:
-          - profile: "Self contained x64"
-            artifact: FoliCon-win-x64-self-contained
-            zip: FoliCon-win-x64-self-contained.zip
-          - profile: "64 dependent"
-            artifact: FoliCon-win-x64-framework-dependent
-            zip: FoliCon-win-x64-framework-dependent.zip
-          - profile: "32 dependent"
-            artifact: FoliCon-win-x86-framework-dependent
-            zip: FoliCon-win-x86-framework-dependent.zip
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -77,26 +64,23 @@ jobs:
           $csproj = $csproj -replace '<AssemblyVersion>.*?</AssemblyVersion>', "<AssemblyVersion>$version</AssemblyVersion>"
           Set-Content FoliCon/FoliCon.csproj $csproj
 
-      - name: Publish (${{ matrix.profile }})
+      - name: Publish
         run: >
           dotnet publish FoliCon/FoliCon.csproj
-          -p:PublishProfile="${{ matrix.profile }}"
+          -p:PublishProfile="64 dependent"
           --configuration Release
 
       - name: Zip output
         shell: pwsh
         run: |
-          $publishDir = "FoliCon/bin/Release/net9.0-windows/publish"
-          $subDir = if ("${{ matrix.profile }}" -eq "Self contained x64") { "frame64" }
-                    elseif ("${{ matrix.profile }}" -eq "64 dependent") { "64Dependant" }
-                    else { "32 dependent" }
-          Compress-Archive -Path "$publishDir/$subDir/*" -DestinationPath "${{ matrix.zip }}"
+          $publishDir = "FoliCon/bin/Release/net9.0-windows/publish/64Dependant"
+          Compress-Archive -Path "$publishDir/*" -DestinationPath "FoliCon-v${{ needs.version.outputs.version }}-x64.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.zip }}
+          name: FoliCon-v${{ needs.version.outputs.version }}-x64
+          path: FoliCon-v${{ needs.version.outputs.version }}-x64.zip
           retention-days: 1
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
       - "v*"
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   version:
     name: Determine version
@@ -88,6 +85,8 @@ jobs:
     needs: [version, publish]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,12 @@ on:
       - "v*"
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   version:
     name: Determine version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.set-version.outputs.version }}
     steps:
@@ -45,6 +44,8 @@ jobs:
     name: Publish FoliCon
     needs: version
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the release process of the `FoliCon` project. The workflow determines the version, builds and publishes the project, packages the output, and creates a GitHub Release with the published artifact.

Key additions in the release workflow:

**Automated Versioning and Publishing:**
* Adds `.github/workflows/release.yml` to automate version determination based on tags or by bumping the minor version if triggered manually or by non-tag pushes.
* Automates the build and publish process for `FoliCon`, including updating version numbers in the `.csproj` file and producing a zipped release artifact.

**Release Creation:**
* Automatically creates a GitHub Release when a version tag is pushed, uploading the generated artifact and generating release notes.