### PR TITLE
feat: Add subfolder processing options and localization

### DIFF
--- a/FoliCon/Modules/Configuration/AppConfig.cs
+++ b/FoliCon/Modules/Configuration/AppConfig.cs
@@ -41,6 +41,7 @@ public class AppConfig : GlobalDataHelper
     public override int FileVersion { get; set; }
 
     public bool SubfolderProcessingEnabled { get; set; }
+    public int SubfolderDepthLimit { get; set; }
 
     public ObservableCollection<Pattern> Patterns { get; set; } =
         [new Pattern("^[0-9]{1,2}x[0-9]{1,2}", false, true), new Pattern("S[0-9]{1,2}E[0-9]", false, true),

--- a/FoliCon/Modules/LangProvider.cs
+++ b/FoliCon/Modules/LangProvider.cs
@@ -13,7 +13,9 @@ namespace FoliCon.Properties.Langs;
 [Localizable(false)]
 public class LangProvider : INotifyPropertyChanged
 {
-    protected LangProvider() { }
+    protected LangProvider()
+    {
+    }
 
     private static string _cultureInfoStr;
     internal static LangProvider Instance => ResourceHelper.GetResource<LangProvider>("FoliConLangs");
@@ -21,11 +23,8 @@ public class LangProvider : INotifyPropertyChanged
 
     public static void SetLang(DependencyObject dependencyObject, DependencyProperty dependencyProperty, string key)
     {
-        BindingOperations.SetBinding(dependencyObject, dependencyProperty, new Binding(key)
-        {
-            Source = Instance,
-            Mode = BindingMode.OneWay
-        });
+        BindingOperations.SetBinding(dependencyObject, dependencyProperty,
+            new Binding(key) { Source = Instance, Mode = BindingMode.OneWay });
     }
 
     public static CultureInfo Culture
@@ -136,6 +135,8 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(Idle));
         OnPropertyChanged(nameof(Ignore));
         OnPropertyChanged(nameof(IgnoreAmbiguousTitle));
+        OnPropertyChanged(nameof(IncludeAlreadyProcessed));
+        OnPropertyChanged(nameof(IncludeAlreadyProcessedTooltip));
         OnPropertyChanged(nameof(InvalidPath));
         OnPropertyChanged(nameof(InvalidRegex));
         OnPropertyChanged(nameof(InvalidRegexMessage));
@@ -144,6 +145,8 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(Load));
         OnPropertyChanged(nameof(LoadingPosters));
         OnPropertyChanged(nameof(MakeIcons));
+        OnPropertyChanged(nameof(MaxDepth));
+        OnPropertyChanged(nameof(MaxDepthTooltip));
         OnPropertyChanged(nameof(ManualExplorer));
         OnPropertyChanged(nameof(MediaRating));
         OnPropertyChanged(nameof(MediaTitle));
@@ -174,6 +177,8 @@ public class LangProvider : INotifyPropertyChanged
         OnPropertyChanged(nameof(PosterIconOverlay));
         OnPropertyChanged(nameof(PosterOverlayTooltip));
         OnPropertyChanged(nameof(Previewer));
+        OnPropertyChanged(nameof(ProcessSelectedFolder));
+        OnPropertyChanged(nameof(ProcessSelectedFolderTooltip));
         OnPropertyChanged(nameof(Professional));
         OnPropertyChanged(nameof(Rating));
         OnPropertyChanged(nameof(RefreshingFolder));
@@ -349,6 +354,12 @@ public class LangProvider : INotifyPropertyChanged
     public string EnableErrorReporting => Lang.EnableErrorReporting;
     public string EnableErrorReportingTip => Lang.EnableErrorReportingTip;
     public string EnableSubfolderProcessing => Lang.EnableSubfolderProcessing;
+    public string IncludeAlreadyProcessed => Lang.IncludeAlreadyProcessed;
+    public string IncludeAlreadyProcessedTooltip => Lang.IncludeAlreadyProcessedTooltip;
+    public string ProcessSelectedFolder => Lang.ProcessSelectedFolder;
+    public string ProcessSelectedFolderTooltip => Lang.ProcessSelectedFolderTooltip;
+    public string MaxDepth => Lang.MaxDepth;
+    public string MaxDepthTooltip => Lang.MaxDepthTooltip;
     public string Enabled => Lang.Enabled;
     public string English => Lang.English;
     public string EnterTitlePlaceholder => Lang.EnterTitlePlaceholder;
@@ -741,7 +752,8 @@ public static class LangKeys
     public static readonly string OnboardingDeviantArtAuthInstructions = nameof(OnboardingDeviantArtAuthInstructions);
     public static readonly string OnboardingDeviantArtBuiltIn = nameof(OnboardingDeviantArtBuiltIn);
     public static readonly string OnboardingDeviantArtCustom = nameof(OnboardingDeviantArtCustom);
-    public static readonly string OnboardingDeviantArtCustomInstructions = nameof(OnboardingDeviantArtCustomInstructions);
+    public static readonly string OnboardingDeviantArtCustomInstructions =
+        nameof(OnboardingDeviantArtCustomInstructions);
     public static readonly string OnboardingDeviantArtValidateConnect = nameof(OnboardingDeviantArtValidateConnect);
     public static readonly string OnboardingConnectDeviantArt = nameof(OnboardingConnectDeviantArt);
     public static readonly string OnboardingDeviantArtConnected = nameof(OnboardingDeviantArtConnected);
@@ -796,5 +808,10 @@ public static class LangKeys
     public static readonly string DeviantArtWatchScopeDescription = nameof(DeviantArtWatchScopeDescription);
     public static readonly string DeviantArtWatchScopeReauthNeeded = nameof(DeviantArtWatchScopeReauthNeeded);
     public static readonly string DeviantArtWatchScopeNotEnabled = nameof(DeviantArtWatchScopeNotEnabled);
-
+    public static readonly string IncludeAlreadyProcessed = nameof(IncludeAlreadyProcessed);
+    public static readonly string IncludeAlreadyProcessedTooltip = nameof(IncludeAlreadyProcessedTooltip);
+    public static readonly string ProcessSelectedFolder = nameof(ProcessSelectedFolder);
+    public static readonly string ProcessSelectedFolderTooltip = nameof(ProcessSelectedFolderTooltip);
+    public static readonly string MaxDepth = nameof(MaxDepth);
+    public static readonly string MaxDepthTooltip = nameof(MaxDepthTooltip);
 }

--- a/FoliCon/Modules/utils/FileUtils.cs
+++ b/FoliCon/Modules/utils/FileUtils.cs
@@ -25,7 +25,7 @@ public static class FileUtils
         ".DS_Store",
         "Thumbs.db"
     ];
-    
+
     /// <summary>
     /// Determines whether a given string value ends with any string within a collection of file extensions.
     /// </summary>
@@ -40,7 +40,7 @@ public static class FileUtils
 
     public static bool IsExcludedFileIdentifier(string fileName) =>
         fileName != null && ExcludedFileIdentifiers.Any(fileName.Contains);
-    
+
     public static bool FileExists(string path) => ShlwApi.PathFileExists(path);
 
     /// <summary>
@@ -67,9 +67,9 @@ public static class FileUtils
 
     public static void DeleteIconsFromFolder(string folderPath)
     {
-        
+
         Logger.Debug("Deleting Icons from: {FolderPath}", folderPath);
-        
+
         var icoFile = Path.Combine(folderPath, $"{IconUtils.GetImageName()}.ico");
         var iniFile = Path.Combine(folderPath, "desktop.ini");
         try
@@ -115,10 +115,16 @@ public static class FileUtils
         Logger.Debug("MediaInfo Deleted from Subfolders of: {FolderPath}", folderPath);
     }
 
-    public static List<string> GetFolderNames(string folderPath)
+    public static List<string> GetFolderNames(string folderPath, bool includeAlreadyProcessed = false)
     {
         var folderNames = new List<string>();
-        if (!string.IsNullOrEmpty(folderPath))
+        if (string.IsNullOrEmpty(folderPath)) return folderNames;
+        if (includeAlreadyProcessed)
+        {
+            folderNames.AddRange(from folder in Directory.GetDirectories(folderPath)
+                select Path.GetFileName(folder));
+        }
+        else
         {
             folderNames.AddRange(from folder in Directory.GetDirectories(folderPath)
                 where !FileExists($@"{folder}\{IconUtils.GetImageName()}.ico")
@@ -525,7 +531,7 @@ public static class FileUtils
             Logger.Warn(ex, "Failed to clear IGDB token cache.");
         }
     }
-    
+
     public static bool CreateDirectory(string path)
     {
         try
@@ -548,13 +554,13 @@ public static class FileUtils
         CreateDirectory(fullPath);
         return fullPath;
     }
-    
+
     public static bool IsCompressedArchive(string fileName)
     {
         var fileExtension = Path.GetExtension(fileName)?.ToLower();
         return CompressedExtensions.Contains(fileExtension);
     }
-    
+
     public static void DeleteDirectoryIfEmpty(string targetDirectoryPath)
     {
         if (!Directory.Exists(targetDirectoryPath))
@@ -585,8 +591,8 @@ public static class FileUtils
                 .Exception(e).Log();
         }
     }
-    
-    
+
+
     private static string FoliConTempPath() => Path.Combine(Path.GetTempPath(), "FoliCon");
 
     private static string FoliConTempDeviationsPath() => Path.Combine(FoliConTempPath(), "Deviations");

--- a/FoliCon/Modules/utils/FileUtils.cs
+++ b/FoliCon/Modules/utils/FileUtils.cs
@@ -115,10 +115,15 @@ public static class FileUtils
         Logger.Debug("MediaInfo Deleted from Subfolders of: {FolderPath}", folderPath);
     }
 
-    public static List<string> GetFolderNames(string folderPath, bool includeAlreadyProcessed = false)
+    public static List<string> GetFolderNames(string folderPath) => GetFolderNames(folderPath, false);
+
+    public static List<string> GetFolderNames(string folderPath, bool includeAlreadyProcessed)
     {
         var folderNames = new List<string>();
-        if (string.IsNullOrEmpty(folderPath)) return folderNames;
+        if (string.IsNullOrEmpty(folderPath))
+        {
+            return folderNames;
+        }
         if (includeAlreadyProcessed)
         {
             folderNames.AddRange(from folder in Directory.GetDirectories(folderPath)

--- a/FoliCon/Modules/utils/IconUtils.cs
+++ b/FoliCon/Modules/utils/IconUtils.cs
@@ -10,11 +10,8 @@ public static class IconUtils
 
     public static string GetImageName() => imageName;
 
-    /// <summary>
-    /// Creates Icons from PNG
-    /// </summary>
     public static async Task<int> MakeIco(string iconMode, string selectedFolder, List<PickedListItem> pickedListDataTable,
-         bool isRatingVisible, bool isMockupVisible, IProgress<ProgressBarData> progressCallback, bool forceOverwrite = false)
+         bool isRatingVisible, bool isMockupVisible, IProgress<ProgressBarData> progressCallback, bool forceOverwrite)
      {
          Logger.Debug(
              "Creating Icons from PNG, Icon Mode: {IconMode}, Selected Folder: {SelectedFolder}, isRatingVisible: {IsRatingVisible}, isMockupVisible: {IsMockupVisible}, ForceOverwrite: {ForceOverwrite}",

--- a/FoliCon/Modules/utils/IconUtils.cs
+++ b/FoliCon/Modules/utils/IconUtils.cs
@@ -14,11 +14,11 @@ public static class IconUtils
     /// Creates Icons from PNG
     /// </summary>
     public static async Task<int> MakeIco(string iconMode, string selectedFolder, List<PickedListItem> pickedListDataTable,
-         bool isRatingVisible, bool isMockupVisible, IProgress<ProgressBarData> progressCallback)
+         bool isRatingVisible, bool isMockupVisible, IProgress<ProgressBarData> progressCallback, bool forceOverwrite = false)
      {
          Logger.Debug(
-             "Creating Icons from PNG, Icon Mode: {IconMode}, Selected Folder: {SelectedFolder}, isRatingVisible: {IsRatingVisible}, isMockupVisible: {IsMockupVisible}",
-             iconMode, selectedFolder, isRatingVisible, isMockupVisible);
+             "Creating Icons from PNG, Icon Mode: {IconMode}, Selected Folder: {SelectedFolder}, isRatingVisible: {IsRatingVisible}, isMockupVisible: {IsMockupVisible}, ForceOverwrite: {ForceOverwrite}",
+             iconMode, selectedFolder, isRatingVisible, isMockupVisible, forceOverwrite);
          var iconProcessedCount = 0;
          var ratingVisibility = isRatingVisible ? "visible" : "hidden";
          var mockupVisibility = isMockupVisible ? "visible" : "hidden";
@@ -36,7 +36,19 @@ public static class IconUtils
              var targetFile = $@"{parentFolder}\{folderName}\{imageName}.ico";
              var pngFilePath = $@"{parentFolder}\{folderName}\{imageName}.png";
 
-             if (FileUtils.FileExists(pngFilePath) && !FileUtils.FileExists(targetFile))
+             if (forceOverwrite && FileUtils.FileExists(targetFile))
+             {
+                 try
+                 {
+                     File.Delete(targetFile);
+                 }
+                 catch (Exception ex)
+                 {
+                     Logger.Warn(ex, "Failed to delete existing ICO: {TargetFile}", targetFile);
+                 }
+             }
+
+             if (FileUtils.FileExists(pngFilePath) && (!FileUtils.FileExists(targetFile) || forceOverwrite))
              {
                  var rating = item.Rating;
                  var mediaTitle = item.Title;

--- a/FoliCon/Modules/utils/IconUtils.cs
+++ b/FoliCon/Modules/utils/IconUtils.cs
@@ -33,44 +33,16 @@ public static class IconUtils
              var targetFile = $@"{parentFolder}\{folderName}\{imageName}.ico";
              var pngFilePath = $@"{parentFolder}\{folderName}\{imageName}.png";
 
-             if (forceOverwrite && FileUtils.FileExists(targetFile))
-             {
-                 try
-                 {
-                     File.Delete(targetFile);
-                 }
-                 catch (Exception ex)
-                 {
-                     Logger.Warn(ex, "Failed to delete existing ICO: {TargetFile}", targetFile);
-                 }
-             }
+             TryDeleteExistingIco(targetFile, forceOverwrite);
 
-             if (FileUtils.FileExists(pngFilePath) && (!FileUtils.FileExists(targetFile) || forceOverwrite))
-             {
-                 var rating = item.Rating;
-                 var mediaTitle = item.Title;
-                 var iconProperties = new IconProperties(iconMode, pngFilePath, rating, ratingVisibility, mockupVisibility, mediaTitle);
-                 await BuildFolderIco(iconProperties, iconOverlay);
+             var created = await TryCreateIconFromPng(pngFilePath, targetFile, forceOverwrite, item,
+                 iconMode, ratingVisibility, mockupVisibility, iconOverlay);
 
-                 lock (lockObj)
-                 {
-                     iconProcessedCount += 1;
-                 }
-
-                 Logger.Info("Icon Created for Folder: {Folder}", folderName);
-                 Logger.Debug("Deleting PNG File: {PngFilePath}", pngFilePath);
-
-                 File.Delete(pngFilePath); //<--IO Exception here
-             }
-
-             if (FileUtils.FileExists(targetFile))
-             {
-                 FileUtils.HideFile(targetFile);
-                 FileUtils.SetFolderIcon($"{imageName}.ico", $@"{parentFolder}\{folderName}");
-             }
+             ApplyFolderIcon(targetFile, folderName, parentFolder);
 
              lock (lockObj)
              {
+                 iconProcessedCount += created ? 1 : 0;
                  extractionProgress.Value = iconProcessedCount;
                  extractionProgress.Text = Lang.CreatingIconWithCount.Format(iconProcessedCount, max);
                  progressCallback.Report(extractionProgress);
@@ -83,6 +55,49 @@ public static class IconUtils
          SHChangeNotify(SHCNE.SHCNE_UPDATEITEM, SHCNF.SHCNF_PATHW, selectedFolder);
          return iconProcessedCount;
      }
+
+    private static void TryDeleteExistingIco(string targetFile, bool forceOverwrite)
+    {
+        if (!forceOverwrite || !FileUtils.FileExists(targetFile))
+        {
+            return;
+        }
+        try
+        {
+            File.Delete(targetFile);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Failed to delete existing ICO: {TargetFile}", targetFile);
+        }
+    }
+
+    private static async Task<bool> TryCreateIconFromPng(string pngFilePath, string targetFile, bool forceOverwrite,
+        PickedListItem item, string iconMode, string ratingVisibility, string mockupVisibility, IconOverlay iconOverlay)
+    {
+        if (!FileUtils.FileExists(pngFilePath) || (FileUtils.FileExists(targetFile) && !forceOverwrite))
+        {
+            return false;
+        }
+
+        var iconProperties = new IconProperties(iconMode, pngFilePath, item.Rating, ratingVisibility, mockupVisibility, item.Title);
+        await BuildFolderIco(iconProperties, iconOverlay);
+
+        Logger.Info("Icon Created for Folder: {Folder}", item.FolderName);
+        Logger.Debug("Deleting PNG File: {PngFilePath}", pngFilePath);
+        File.Delete(pngFilePath);
+        return true;
+    }
+
+    private static void ApplyFolderIcon(string targetFile, string folderName, string parentFolder)
+    {
+        if (!FileUtils.FileExists(targetFile))
+        {
+            return;
+        }
+        FileUtils.HideFile(targetFile);
+        FileUtils.SetFolderIcon($"{imageName}.ico", $@"{parentFolder}\{folderName}");
+    }
 
     /// <summary>
     /// Converts From PNG to ICO

--- a/FoliCon/Properties/Langs/Lang.Designer.cs
+++ b/FoliCon/Properties/Langs/Lang.Designer.cs
@@ -2349,5 +2349,59 @@ namespace FoliCon.Properties.Langs {
                 return ResourceManager.GetString("DeviantArtWatchScopeNotEnabled", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include folders with existing icons.
+        /// </summary>
+        public static string IncludeAlreadyProcessed {
+            get {
+                return ResourceManager.GetString("IncludeAlreadyProcessed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When enabled, folders that already have FoliCon icons will also be processed and their icons can be updated..
+        /// </summary>
+        public static string IncludeAlreadyProcessedTooltip {
+            get {
+                return ResourceManager.GetString("IncludeAlreadyProcessedTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include selected folder.
+        /// </summary>
+        public static string ProcessSelectedFolder {
+            get {
+                return ResourceManager.GetString("ProcessSelectedFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When enabled, the selected folder itself will also be processed for icon creation, in addition to its subfolders..
+        /// </summary>
+        public static string ProcessSelectedFolderTooltip {
+            get {
+                return ResourceManager.GetString("ProcessSelectedFolderTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max depth.
+        /// </summary>
+        public static string MaxDepth {
+            get {
+                return ResourceManager.GetString("MaxDepth", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum depth of subfolder processing. 0 = unlimited (process all levels)..
+        /// </summary>
+        public static string MaxDepthTooltip {
+            get {
+                return ResourceManager.GetString("MaxDepthTooltip", resourceCulture);
+            }
+        }
     }
 }

--- a/FoliCon/Properties/Langs/Lang.ar.resx
+++ b/FoliCon/Properties/Langs/Lang.ar.resx
@@ -892,4 +892,22 @@
   <data name="DeviantArtWatchScopeNotEnabled" xml:space="preserve">
       <value>الوصول عبر جدار المتابعة غير مفعّل. فعّل "الوصول عبر جدار المتابعة" في إعدادات DeviantArt وأعد الاتصال لاستخدام هذه الميزة.</value>
     </data>
+  <data name="IncludeAlreadyProcessed" xml:space="preserve">
+      <value>تضمين المجلدات ذات الأيقونات الموجودة</value>
+    </data>
+  <data name="IncludeAlreadyProcessedTooltip" xml:space="preserve">
+      <value>عند التمكين، ستتم معالجة المجلدات التي تحتوي بالفعل على أيقونات FoliCon ويمكن تحديث أيقوناتها.</value>
+    </data>
+  <data name="ProcessSelectedFolder" xml:space="preserve">
+      <value>تضمين المجلد المحدد</value>
+    </data>
+  <data name="ProcessSelectedFolderTooltip" xml:space="preserve">
+      <value>عند التمكين، ستتم معالجة المجلد المحدد نفسه لإنشاء الأيقونات، بالإضافة إلى مجلداته الفرعية.</value>
+    </data>
+  <data name="MaxDepth" xml:space="preserve">
+    <value>الحد الأقصى للعمق</value>
+  </data>
+  <data name="MaxDepthTooltip" xml:space="preserve">
+    <value>الحد الأقصى لعمق معالجة المجلدات الفرعية. 0 = غير محدود (معالجة جميع المستويات).</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.es.resx
+++ b/FoliCon/Properties/Langs/Lang.es.resx
@@ -893,4 +893,22 @@ y actualizar la caché de iconos?</value>
   <data name="DeviantArtWatchScopeNotEnabled" xml:space="preserve">
       <value>El acceso a iconos por muro de seguidores no está activado. Activa "Acceso a iconos por muro de seguidores" en la configuración de DeviantArt y vuelve a conectarte para usar esta función.</value>
     </data>
+  <data name="IncludeAlreadyProcessed" xml:space="preserve">
+      <value>Incluir carpetas con iconos existentes</value>
+    </data>
+  <data name="IncludeAlreadyProcessedTooltip" xml:space="preserve">
+      <value>Cuando está activado, las carpetas que ya tienen iconos de FoliCon también serán procesadas y sus iconos podrán ser actualizados.</value>
+    </data>
+  <data name="ProcessSelectedFolder" xml:space="preserve">
+      <value>Incluir carpeta seleccionada</value>
+    </data>
+  <data name="ProcessSelectedFolderTooltip" xml:space="preserve">
+      <value>Cuando está activado, la carpeta seleccionada también será procesada para la creación de iconos, además de sus subcarpetas.</value>
+    </data>
+  <data name="MaxDepth" xml:space="preserve">
+    <value>Profundidad máxima</value>
+  </data>
+  <data name="MaxDepthTooltip" xml:space="preserve">
+    <value>Profundidad máxima del procesamiento de subcarpetas. 0 = sin límite (procesar todos los niveles).</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.hi.resx
+++ b/FoliCon/Properties/Langs/Lang.hi.resx
@@ -893,4 +893,22 @@
   <data name="DeviantArtWatchScopeNotEnabled" xml:space="preserve">
       <value>फ़ॉलोवर वॉल आइकन एक्सेस सक्षम नहीं है। इस सुविधा का उपयोग करने के लिए DeviantArt सेटअप में "फ़ॉलोवर वॉल आइकन एक्सेस" सक्षम करें और पुनः कनेक्ट करें।</value>
     </data>
+  <data name="IncludeAlreadyProcessed" xml:space="preserve">
+      <value>मौजूदा आइकन वाले फ़ोल्डर शामिल करें</value>
+    </data>
+  <data name="IncludeAlreadyProcessedTooltip" xml:space="preserve">
+      <value>सक्षम होने पर, जिन फ़ोल्डरों में पहले से FoliCon आइकन हैं, उन्हें भी प्रोसेस किया जाएगा और उनके आइकन अपडेट किए जा सकेंगे।</value>
+    </data>
+  <data name="ProcessSelectedFolder" xml:space="preserve">
+      <value>चयनित फ़ोल्डर शामिल करें</value>
+    </data>
+  <data name="ProcessSelectedFolderTooltip" xml:space="preserve">
+      <value>सक्षम होने पर, चयनित फ़ोल्डर को भी आइकन निर्माण के लिए प्रोसेस किया जाएगा, उसके सबफ़ोल्डर के अतिरिक्त।</value>
+    </data>
+  <data name="MaxDepth" xml:space="preserve">
+    <value>अधिकतम गहराई</value>
+  </data>
+  <data name="MaxDepthTooltip" xml:space="preserve">
+    <value>सबफ़ोल्डर प्रोसेसिंग की अधिकतम गहराई। 0 = असीमित (सभी स्तरों को प्रोसेस करें)।</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.ja.resx
+++ b/FoliCon/Properties/Langs/Lang.ja.resx
@@ -892,4 +892,22 @@ and refresh Icon Cache?</value>
   <data name="DeviantArtWatchScopeNotEnabled" xml:space="preserve">
       <value>フォローウォール アイコンアクセスが有効ではありません。DeviantArt の設定で「フォローウォール アイコンアクセス」を有効にして再接続してください。</value>
     </data>
+  <data name="IncludeAlreadyProcessed" xml:space="preserve">
+      <value>既存のアイコンがあるフォルダーを含める</value>
+    </data>
+  <data name="IncludeAlreadyProcessedTooltip" xml:space="preserve">
+      <value>有効にすると、FoliConのアイコンが既にあるフォルダーも処理され、アイコンを更新できます。</value>
+    </data>
+  <data name="ProcessSelectedFolder" xml:space="preserve">
+      <value>選択したフォルダーを含める</value>
+    </data>
+  <data name="ProcessSelectedFolderTooltip" xml:space="preserve">
+      <value>有効にすると、サブフォルダーに加えて、選択したフォルダー自体もアイコン作成のために処理されます。</value>
+    </data>
+  <data name="MaxDepth" xml:space="preserve">
+    <value>最大深度</value>
+  </data>
+  <data name="MaxDepthTooltip" xml:space="preserve">
+    <value>サブフォルダー処理の最大深度。0 = 無制限（すべてのレベルを処理）。</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.pt.resx
+++ b/FoliCon/Properties/Langs/Lang.pt.resx
@@ -892,4 +892,22 @@ e renovar o cache dos Ícones?</value>
   <data name="DeviantArtWatchScopeNotEnabled" xml:space="preserve">
       <value>O acesso a ícones por muro de seguidores não está ativado. Ative o "Acesso a ícones por muro de seguidores" nas definições do DeviantArt e volte a ligar-se para usar esta funcionalidade.</value>
     </data>
+  <data name="IncludeAlreadyProcessed" xml:space="preserve">
+      <value>Incluir pastas com ícones existentes</value>
+    </data>
+  <data name="IncludeAlreadyProcessedTooltip" xml:space="preserve">
+      <value>Quando ativado, as pastas que já possuem ícones do FoliCon também serão processadas e seus ícones poderão ser atualizados.</value>
+    </data>
+  <data name="ProcessSelectedFolder" xml:space="preserve">
+      <value>Incluir pasta selecionada</value>
+    </data>
+  <data name="ProcessSelectedFolderTooltip" xml:space="preserve">
+      <value>Quando ativado, a pasta selecionada também será processada para criação de ícones, além de suas subpastas.</value>
+    </data>
+  <data name="MaxDepth" xml:space="preserve">
+    <value>Profundidade máxima</value>
+  </data>
+  <data name="MaxDepthTooltip" xml:space="preserve">
+    <value>Profundidade máxima do processamento de subpastas. 0 = ilimitado (processar todos os níveis).</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.resx
+++ b/FoliCon/Properties/Langs/Lang.resx
@@ -893,4 +893,22 @@ and refresh Icon Cache?</value>
     <data name="DeviantArtWatchScopeNotEnabled" xml:space="preserve">
       <value>Watcher-gated icon access is not enabled. Enable "Watcher-Gated Icon Access" in the DeviantArt setup and reconnect to use this feature.</value>
     </data>
+    <data name="IncludeAlreadyProcessed" xml:space="preserve">
+      <value>Include folders with existing icons</value>
+    </data>
+    <data name="IncludeAlreadyProcessedTooltip" xml:space="preserve">
+      <value>When enabled, folders that already have FoliCon icons will also be processed and their icons can be updated.</value>
+    </data>
+    <data name="ProcessSelectedFolder" xml:space="preserve">
+      <value>Include selected folder</value>
+    </data>
+    <data name="ProcessSelectedFolderTooltip" xml:space="preserve">
+      <value>When enabled, the selected folder itself will also be processed for icon creation, in addition to its subfolders.</value>
+    </data>
+    <data name="MaxDepth" xml:space="preserve">
+      <value>Max depth</value>
+    </data>
+    <data name="MaxDepthTooltip" xml:space="preserve">
+      <value>Maximum depth of subfolder processing. 0 = unlimited (process all levels).</value>
+    </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.ru.resx
+++ b/FoliCon/Properties/Langs/Lang.ru.resx
@@ -893,4 +893,22 @@
   <data name="DeviantArtWatchScopeNotEnabled" xml:space="preserve">
       <value>Доступ к иконкам через стену подписчиков не включён. Включите «Доступ к иконкам через стену подписчиков» в настройках DeviantArt и подключитесь заново.</value>
     </data>
+  <data name="IncludeAlreadyProcessed" xml:space="preserve">
+      <value>Включить папки с существующими иконками</value>
+    </data>
+  <data name="IncludeAlreadyProcessedTooltip" xml:space="preserve">
+      <value>Если включено, папки с уже существующими иконками FoliCon также будут обработаны, и их иконки могут быть обновлены.</value>
+    </data>
+  <data name="ProcessSelectedFolder" xml:space="preserve">
+      <value>Включить выбранную папку</value>
+    </data>
+  <data name="ProcessSelectedFolderTooltip" xml:space="preserve">
+      <value>Если включено, выбранная папка также будет обработана для создания иконок, в дополнение к её подпапкам.</value>
+    </data>
+  <data name="MaxDepth" xml:space="preserve">
+    <value>Макс. глубина</value>
+  </data>
+  <data name="MaxDepthTooltip" xml:space="preserve">
+    <value>Максимальная глубина обработки подпапок. 0 = без ограничений (обрабатывать все уровни).</value>
+  </data>
 </root>

--- a/FoliCon/Properties/Langs/Lang.zh.resx
+++ b/FoliCon/Properties/Langs/Lang.zh.resx
@@ -892,4 +892,22 @@ and refresh Icon Cache?</value>
   <data name="DeviantArtWatchScopeNotEnabled" xml:space="preserve">
       <value>关注墙图标访问未启用。请在 DeviantArt 设置中启用「关注墙图标访问」并重新连接以使用此功能。</value>
     </data>
+  <data name="IncludeAlreadyProcessed" xml:space="preserve">
+      <value>包含已有图标的文件夹</value>
+    </data>
+  <data name="IncludeAlreadyProcessedTooltip" xml:space="preserve">
+      <value>启用后，已有 FoliCon 图标的文件夹也会被处理，其图标可以被更新。</value>
+    </data>
+  <data name="ProcessSelectedFolder" xml:space="preserve">
+      <value>包含所选文件夹</value>
+    </data>
+  <data name="ProcessSelectedFolderTooltip" xml:space="preserve">
+      <value>启用后，所选文件夹本身也会被处理以创建图标，此外还会处理其子文件夹。</value>
+    </data>
+  <data name="MaxDepth" xml:space="preserve">
+    <value>最大深度</value>
+  </data>
+  <data name="MaxDepthTooltip" xml:space="preserve">
+    <value>子文件夹处理的最大深度。0 = 无限制（处理所有层级）。</value>
+  </data>
 </root>

--- a/FoliCon/ViewModels/MainWindowViewModel.cs
+++ b/FoliCon/ViewModels/MainWindowViewModel.cs
@@ -484,25 +484,11 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
             var (folderPath, depth) = folderQueue.Dequeue();
             var subfolderNames = FileUtils.GetFolderNames(folderPath, IncludeAlreadyProcessed);
 
-            // Process the selected folder itself if ProcessSelectedFolder is enabled
-            // Only if it doesn't already have an icon (unless IncludeAlreadyProcessed is checked)
-            if (!isRootProcessed && ProcessSelectedFolder && folderPath == rootFolderPath
-                && (IncludeAlreadyProcessed || !FileUtils.FileExists(Path.Combine(folderPath, $"{IconUtils.GetImageName()}.ico"))))
+            var (skipAll, processed) = await TryProcessSelectedFolder(rootFolderPath, folderPath, isRootProcessed);
+            isRootProcessed |= processed;
+            if (skipAll)
             {
-                isRootProcessed = true;
-                var folderName = Path.GetFileName(folderPath);
-                if (!string.IsNullOrEmpty(folderName))
-                {
-                    var parentPath = Path.GetDirectoryName(folderPath);
-                    if (!string.IsNullOrEmpty(parentPath))
-                    {
-                        StatusBarProperties.TotalFolders++;
-                        if (await ProcessItemAsync(parentPath, folderName))
-                        {
-                            break; // Skip All was selected
-                        }
-                    }
-                }
+                break;
             }
 
             if (subfolderNames.Count == 0)
@@ -511,13 +497,10 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
             }
 
             StatusBarProperties.TotalFolders += subfolderNames.Count;
-
-            foreach (var itemTitle in subfolderNames)
+            skipAll = await ProcessFolderItems(folderPath, subfolderNames);
+            if (skipAll)
             {
-                if (await ProcessItemAsync(folderPath, itemTitle))
-                {
-                    break; // Skip All was selected
-                }
+                break;
             }
 
             if (Services.Settings.SubfolderProcessingEnabled && (maxDepth == 0 || depth + 1 < maxDepth))
@@ -525,6 +508,41 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
                 ProcessSubfolders(folderPath, folderQueue, depth + 1);
             }
         }
+    }
+
+    private async Task<(bool skipAll, bool rootProcessed)> TryProcessSelectedFolder(string rootFolderPath, string folderPath, bool isRootProcessed)
+    {
+        if (isRootProcessed || !ProcessSelectedFolder || folderPath != rootFolderPath)
+        {
+            return (false, false);
+        }
+        if (!IncludeAlreadyProcessed && FileUtils.FileExists(Path.Combine(folderPath, $"{IconUtils.GetImageName()}.ico")))
+        {
+            return (false, true);
+        }
+
+        var folderName = Path.GetFileName(folderPath);
+        var parentPath = Path.GetDirectoryName(folderPath);
+        if (string.IsNullOrEmpty(folderName) || string.IsNullOrEmpty(parentPath))
+        {
+            return (false, true);
+        }
+
+        StatusBarProperties.TotalFolders++;
+        var skipAll = await ProcessItemAsync(parentPath, folderName);
+        return (skipAll, true);
+    }
+
+    private async Task<bool> ProcessFolderItems(string folderPath, List<string> subfolderNames)
+    {
+        foreach (var itemTitle in subfolderNames)
+        {
+            if (await ProcessItemAsync(folderPath, itemTitle))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     private async Task<bool> ProcessItemAsync(string folderPath, string itemTitle)
@@ -739,40 +757,59 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
             Logger.Trace($"Processing Folder: {folderPath}");
             var subfolderNames = FileUtils.GetFolderNames(folderPath, IncludeAlreadyProcessed);
 
-            // Include the selected folder itself if ProcessSelectedFolder is enabled
-            // Only if it doesn't already have an icon (unless IncludeAlreadyProcessed is checked)
-            if (!isRootProcessed && ProcessSelectedFolder && folderPath == initialFolderPath
-                && (IncludeAlreadyProcessed || !FileUtils.FileExists(Path.Combine(folderPath, $"{IconUtils.GetImageName()}.ico"))))
-            {
-                isRootProcessed = true;
-                var folderName = Path.GetFileName(folderPath);
-                if (!string.IsNullOrEmpty(folderName))
-                {
-                    subfolderNames.Add(folderName);
-                }
-            }
+            TryIncludeSelectedFolder(subfolderNames, initialFolderPath, folderPath, ref isRootProcessed);
 
             if (subfolderNames.Count == 0)
             {
                 continue;
             }
-            StatusBarProperties.TotalFolders += subfolderNames.Count;
-            StatusBarProperties.AppStatus = Lang.Searching;
-            _dialogService.ShowProSearchResult(folderPath, subfolderNames, _pickedListDataTable, _imgDownloadList,
-                _dArtObject, _ => { });
-            Logger.Debug("ProcessProfessionalMode: found {ResultCount} results, adding to final list", _pickedListDataTable.Count);
-            FinalListViewData.Data.AddRange(_pickedListDataTable);
-            StatusBarProperties.ProcessedFolder = _pickedListDataTable.Count;
-            if (!Services.Settings.SubfolderProcessingEnabled || (maxDepth != 0 && depth + 1 >= maxDepth))
-            {
-                continue;
-            }
-            Logger.Trace("Subfolder Processing Enabled, Adding Subfolders.");
-            var subFolders = FileUtils.GetAllSubFolders(folderPath, Services.Settings.Patterns);
-            foreach (var subFolder in subFolders)
-            {
-                foldersQueue.Enqueue((subFolder, depth + 1));
-            }
+
+            ProcessProfessionalFolder(folderPath, subfolderNames);
+            EnqueueSubfoldersIfEnabled(folderPath, depth, maxDepth, foldersQueue);
+        }
+    }
+
+    private void TryIncludeSelectedFolder(List<string> subfolderNames, string initialFolderPath, string folderPath, ref bool isRootProcessed)
+    {
+        if (isRootProcessed || !ProcessSelectedFolder || folderPath != initialFolderPath)
+        {
+            return;
+        }
+        if (!IncludeAlreadyProcessed && FileUtils.FileExists(Path.Combine(folderPath, $"{IconUtils.GetImageName()}.ico")))
+        {
+            isRootProcessed = true;
+            return;
+        }
+        isRootProcessed = true;
+        var folderName = Path.GetFileName(folderPath);
+        if (!string.IsNullOrEmpty(folderName))
+        {
+            subfolderNames.Add(folderName);
+        }
+    }
+
+    private void ProcessProfessionalFolder(string folderPath, List<string> subfolderNames)
+    {
+        StatusBarProperties.TotalFolders += subfolderNames.Count;
+        StatusBarProperties.AppStatus = Lang.Searching;
+        _dialogService.ShowProSearchResult(folderPath, subfolderNames, _pickedListDataTable, _imgDownloadList,
+            _dArtObject, _ => { });
+        Logger.Debug("ProcessProfessionalMode: found {ResultCount} results, adding to final list", _pickedListDataTable.Count);
+        FinalListViewData.Data.AddRange(_pickedListDataTable);
+        StatusBarProperties.ProcessedFolder = _pickedListDataTable.Count;
+    }
+
+    private static void EnqueueSubfoldersIfEnabled(string folderPath, int depth, int maxDepth, Queue<(string path, int depth)> foldersQueue)
+    {
+        if (!Services.Settings.SubfolderProcessingEnabled || (maxDepth != 0 && depth + 1 >= maxDepth))
+        {
+            return;
+        }
+        Logger.Trace("Subfolder Processing Enabled, Adding Subfolders.");
+        var subFolders = FileUtils.GetAllSubFolders(folderPath, Services.Settings.Patterns);
+        foreach (var subFolder in subFolders)
+        {
+            foldersQueue.Enqueue((subFolder, depth + 1));
         }
     }
 

--- a/FoliCon/ViewModels/MainWindowViewModel.cs
+++ b/FoliCon/ViewModels/MainWindowViewModel.cs
@@ -11,103 +11,97 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
 
     #region Variables
 
-    private string _selectedFolder;
-    private string _title = "FoliCon";
-    private bool _isRatingVisible = true;
-    private bool _isPosterMockupUsed = true;
-    private bool _isBusy;
-    private bool _isMakeEnabled;
-    private bool _isSkipAmbiguous;
-    private string _iconMode = "Poster";
-    private string _searchMode = MediaTypes.movie;
-    private bool _isSearchModeVisible = true;
-    private bool _stopIconDownload;
-    private Languages _appLanguage;
     private TMDbClient _tmdbClient;
     private IgdbClass _igdbObject;
     private Tmdb _tmdbObject;
     private DArt _dArtObject;
-    private bool _isPosterWindowShown;
-    private bool _enableErrorReporting;
-    private ProgressBarData _busyIndicatorProperties;
 
-    private ListViewData _finalListViewData;
     private List<ImageToDownload> _imgDownloadList = [];
     private List<PickedListItem> _pickedListDataTable = [];
     private bool IsObjectsInitialized { get; set; }
 
     public bool IsPosterWindowShown
     {
-        get => _isPosterWindowShown; set
+        get;
+        set
         {
             IsSkipAmbiguousEnabled = !value;
-            SetProperty(ref _isPosterWindowShown, value);
+            SetProperty(ref field, value);
         }
     }
-    private bool _isSkipAmbiguousEnabled;
-    public bool IsSkipAmbiguousEnabled { get => _isSkipAmbiguousEnabled; set => SetProperty(ref _isSkipAmbiguousEnabled, value); }
+
+    public bool IsSkipAmbiguousEnabled
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
     public bool EnableErrorReporting
     {
-        get => _enableErrorReporting;
+        get;
         set
         {
             LogManager.Configuration.SentryConfig(value);
-            SetProperty(ref _enableErrorReporting, value);
+            SetProperty(ref field, value);
         }
     }
 
     public bool IsSearchModeVisible
     {
-        get => _isSearchModeVisible;
-        set => SetProperty(ref _isSearchModeVisible, value);
-    }
+        get;
+        set => SetProperty(ref field, value);
+    } = true;
 
     public ListViewData FinalListViewData
     {
-        get => _finalListViewData;
-        private set => SetProperty(ref _finalListViewData, value);
+        get;
+        private set => SetProperty(ref field, value);
     }
 
     private readonly IDialogService _dialogService;
-    private FoliconThemes _theme;
-    private DirectoryPermissionsResult _directoryPermissionResult;
     public StatusBarData StatusBarProperties { get; set; }
-    public ProgressBarData BusyIndicatorProperties { get => _busyIndicatorProperties; set => SetProperty(ref _busyIndicatorProperties, value); }
+
+    public ProgressBarData BusyIndicatorProperties
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
     private List<string> Fnames { get; set; } = [];
 
     public bool IsMakeEnabled
     {
-        get => _isMakeEnabled;
-        set => SetProperty(ref _isMakeEnabled, value);
+        get;
+        set => SetProperty(ref field, value);
     }
 
     public bool IsSkipAmbiguous
     {
-        get => _isSkipAmbiguous;
-        set => SetProperty(ref _isSkipAmbiguous, value);
+        get;
+        set => SetProperty(ref field, value);
     }
 
     private bool StopIconDownload
     {
-        get => _stopIconDownload;
-        set => SetProperty(ref _stopIconDownload, value);
+        get;
+        set => SetProperty(ref field, value);
     }
 
     private string IconMode
     {
-        get => _iconMode;
+        get;
         set
         {
-            SetProperty(ref _iconMode, value);
+            SetProperty(ref field, value);
             IsSearchModeVisible = value != professionalMode;
         }
-    }
+    } = "Poster";
 
     private string SearchMode
     {
-        get => _searchMode;
-        set => SetProperty(ref _searchMode, value);
-    }
+        get;
+        set => SetProperty(ref field, value);
+    } = MediaTypes.movie;
 
     #endregion Variables
 
@@ -115,10 +109,10 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
 
     public string SelectedFolder
     {
-        get => _selectedFolder;
+        get;
         set
         {
-            SetProperty(ref _selectedFolder, value);
+            SetProperty(ref field, value);
             if (value != null)
             {
                 DirectoryPermissionsResult = FileUtils.CheckDirectoryPermissions(value);
@@ -128,45 +122,46 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
 
     public DirectoryPermissionsResult DirectoryPermissionsResult
     {
-        get => _directoryPermissionResult;
-        set => SetProperty(ref _directoryPermissionResult, value);
+        get;
+        set => SetProperty(ref field, value);
     }
 
     public string Title
     {
-        get => _title;
-        set => SetProperty(ref _title, value);
-    }
+        get;
+        set => SetProperty(ref field, value);
+    } = "FoliCon";
 
     public bool IsRatingVisible
     {
-        get => _isRatingVisible;
-        set => SetProperty(ref _isRatingVisible, value);
-    }
+        get;
+        set => SetProperty(ref field, value);
+    } = true;
 
     public bool IsPosterMockupUsed
     {
-        get => _isPosterMockupUsed;
-        set => SetProperty(ref _isPosterMockupUsed, value);
-    }
+        get;
+        set => SetProperty(ref field, value);
+    } = true;
 
     public bool IsBusy
     {
-        get => _isBusy;
-        set => SetProperty(ref _isBusy, value);
+        get;
+        set => SetProperty(ref field, value);
     }
 
     public Languages AppLanguage
     {
-        get => _appLanguage;
-        set => SetProperty(ref _appLanguage, value);
+        get;
+        set => SetProperty(ref field, value);
     }
+
     public FoliconThemes Theme
     {
-        get => _theme;
+        get;
         set
         {
-            SetProperty(ref _theme, value);
+            SetProperty(ref field, value);
             switch (value)
             {
                 case FoliconThemes.Light:
@@ -185,6 +180,18 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
                     break;
             }
         }
+    }
+
+    public bool IncludeAlreadyProcessed
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
+    public bool ProcessSelectedFolder
+    {
+        get;
+        set => SetProperty(ref field, value);
     }
 
     #endregion GetterSetters
@@ -376,8 +383,10 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
     {
         if (Directory.Exists(SelectedFolder))
         {
-            Fnames = FileUtils.GetFolderNames(SelectedFolder);
-            if (Fnames.Count != 0 || Services.Settings.SubfolderProcessingEnabled)
+            Fnames = FileUtils.GetFolderNames(SelectedFolder, IncludeAlreadyProcessed);
+            var isProcessSelectedFolderEffective = ProcessSelectedFolder
+                && (IncludeAlreadyProcessed || !FileUtils.FileExists(Path.Combine(SelectedFolder, $"{IconUtils.GetImageName()}.ico")));
+            if (Fnames.Count != 0 || Services.Settings.SubfolderProcessingEnabled || isProcessSelectedFolderEffective)
             {
                 return true;
             }
@@ -465,13 +474,36 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
 
     private async Task ProcessPosterFolderAsync(string rootFolderPath)
     {
-        var folderQueue = new Queue<string>();
-        folderQueue.Enqueue(rootFolderPath);
+        var folderQueue = new Queue<(string path, int depth)>();
+        folderQueue.Enqueue((rootFolderPath, 0));
+        var maxDepth = Services.Settings.SubfolderDepthLimit;
+        var isRootProcessed = false;
 
         while (folderQueue.Count > 0)
         {
-            var folderPath = folderQueue.Dequeue();
-            var subfolderNames = FileUtils.GetFolderNames(folderPath);
+            var (folderPath, depth) = folderQueue.Dequeue();
+            var subfolderNames = FileUtils.GetFolderNames(folderPath, IncludeAlreadyProcessed);
+
+            // Process the selected folder itself if ProcessSelectedFolder is enabled
+            // Only if it doesn't already have an icon (unless IncludeAlreadyProcessed is checked)
+            if (!isRootProcessed && ProcessSelectedFolder && folderPath == rootFolderPath
+                && (IncludeAlreadyProcessed || !FileUtils.FileExists(Path.Combine(folderPath, $"{IconUtils.GetImageName()}.ico"))))
+            {
+                isRootProcessed = true;
+                var folderName = Path.GetFileName(folderPath);
+                if (!string.IsNullOrEmpty(folderName))
+                {
+                    var parentPath = Path.GetDirectoryName(folderPath);
+                    if (!string.IsNullOrEmpty(parentPath))
+                    {
+                        StatusBarProperties.TotalFolders++;
+                        if (await ProcessItemAsync(parentPath, folderName))
+                        {
+                            break; // Skip All was selected
+                        }
+                    }
+                }
+            }
 
             if (subfolderNames.Count == 0)
             {
@@ -488,9 +520,9 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
                 }
             }
 
-            if (Services.Settings.SubfolderProcessingEnabled)
+            if (Services.Settings.SubfolderProcessingEnabled && (maxDepth == 0 || depth + 1 < maxDepth))
             {
-                ProcessSubfolders(folderPath, folderQueue);
+                ProcessSubfolders(folderPath, folderQueue, depth + 1);
             }
         }
     }
@@ -542,11 +574,14 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
         }
     }
 
-    private static void ProcessSubfolders(string folderPath, Queue<string> folderQueue)
+    private static void ProcessSubfolders(string folderPath, Queue<(string path, int depth)> folderQueue, int depth)
     {
         Logger.Trace("Subfolder Processing Enabled, Processing Subfolders.");
         var folders = FileUtils.GetAllSubFolders(folderPath, Services.Settings.Patterns);
-        folders.ForEach(folderQueue.Enqueue);
+        foreach (var folder in folders)
+        {
+            folderQueue.Enqueue((folder, depth));
+        }
     }
 
     private async Task<(ResultResponse response, ParsedTitle parsedTitle, bool isPickedById, string mediaType)> PerformPreprocessing(string itemTitle, string fullFolderPath)
@@ -693,32 +728,51 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
     private void ProcessProfessionalMode(string initialFolderPath)
     {
         Logger.Debug("Entered ProcessProfessionalMode method");
-        // Create a queue to hold the folders
-        var foldersQueue = new Queue<string>();
-        foldersQueue.Enqueue(initialFolderPath);
+        var foldersQueue = new Queue<(string path, int depth)>();
+        foldersQueue.Enqueue((initialFolderPath, 0));
+        var maxDepth = Services.Settings.SubfolderDepthLimit;
+        var isRootProcessed = false;
+
         while (foldersQueue.Count > 0)
         {
-            var folderPath = foldersQueue.Dequeue();
+            var (folderPath, depth) = foldersQueue.Dequeue();
             Logger.Trace($"Processing Folder: {folderPath}");
-            var subfolderNames = FileUtils.GetFolderNames(folderPath);
+            var subfolderNames = FileUtils.GetFolderNames(folderPath, IncludeAlreadyProcessed);
+
+            // Include the selected folder itself if ProcessSelectedFolder is enabled
+            // Only if it doesn't already have an icon (unless IncludeAlreadyProcessed is checked)
+            if (!isRootProcessed && ProcessSelectedFolder && folderPath == initialFolderPath
+                && (IncludeAlreadyProcessed || !FileUtils.FileExists(Path.Combine(folderPath, $"{IconUtils.GetImageName()}.ico"))))
+            {
+                isRootProcessed = true;
+                var folderName = Path.GetFileName(folderPath);
+                if (!string.IsNullOrEmpty(folderName))
+                {
+                    subfolderNames.Add(folderName);
+                }
+            }
+
             if (subfolderNames.Count == 0)
             {
                 continue;
             }
-            StatusBarProperties.TotalFolders+= subfolderNames.Count;
+            StatusBarProperties.TotalFolders += subfolderNames.Count;
             StatusBarProperties.AppStatus = Lang.Searching;
             _dialogService.ShowProSearchResult(folderPath, subfolderNames, _pickedListDataTable, _imgDownloadList,
                 _dArtObject, _ => { });
             Logger.Debug("ProcessProfessionalMode: found {ResultCount} results, adding to final list", _pickedListDataTable.Count);
             FinalListViewData.Data.AddRange(_pickedListDataTable);
             StatusBarProperties.ProcessedFolder = _pickedListDataTable.Count;
-            if (!Services.Settings.SubfolderProcessingEnabled)
+            if (!Services.Settings.SubfolderProcessingEnabled || (maxDepth != 0 && depth + 1 >= maxDepth))
             {
                 continue;
             }
             Logger.Trace("Subfolder Processing Enabled, Adding Subfolders.");
             var subFolders = FileUtils.GetAllSubFolders(folderPath, Services.Settings.Patterns);
-            subFolders.ForEach(foldersQueue.Enqueue);
+            foreach (var subFolder in subFolders)
+            {
+                foldersQueue.Enqueue((subFolder, depth + 1));
+            }
         }
     }
 
@@ -998,7 +1052,8 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
             _pickedListDataTable,
             IsRatingVisible,
             IsPosterMockupUsed,
-            new Progress<ProgressBarData>(value => BusyIndicatorProperties = value)));
+            new Progress<ProgressBarData>(value => BusyIndicatorProperties = value),
+            IncludeAlreadyProcessed));
         StatusBarProperties.ProcessedIcon = iconProcessedCount;
         IsBusy = false;
         var info = new GrowlInfo
@@ -1140,6 +1195,8 @@ public sealed class MainWindowViewModel : BindableBase, IFileDragDropTarget, IDi
             .Property(p => p.AppLanguage, Languages.English)
             .Property(p => p.Theme, FoliconThemes.System)
             .Property(p => p.EnableErrorReporting, false)
+            .Property(p => p.IncludeAlreadyProcessed, false)
+            .Property(p => p.ProcessSelectedFolder, false)
             .PersistOn(nameof(PropertyChanged));
         Services.Tracker.Track(this);
     }

--- a/FoliCon/ViewModels/SubfolderProcessingViewModel.cs
+++ b/FoliCon/ViewModels/SubfolderProcessingViewModel.cs
@@ -12,38 +12,42 @@ public class SubfolderProcessingViewModel : BindableBase, IDialogAware
 
     public string Title => Lang.SubfolderProcessing;
 
-    private ObservableCollection<Pattern> _patterns;
-    private bool _subfolderProcessingEnabled;
-        
     public ObservableCollection<Pattern> PatternsList
     {
-        get => _patterns;
-        set => SetProperty(ref _patterns, value);
+        get;
+        set => SetProperty(ref field, value);
     }
-        
+
     public bool SubfolderProcessingEnabled
     {
-        get => _subfolderProcessingEnabled;
-        set => SetProperty(ref _subfolderProcessingEnabled, value);
+        get;
+        set => SetProperty(ref field, value);
     }
-        
+
+    public int SubfolderDepthLimit
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
     #endregion
 
     #region Commands
 
     public DelegateCommand<string> AddCommand { get; }
     public DelegateCommand<Pattern> RemoveCommand { get; }
-    
+
     #endregion
     public SubfolderProcessingViewModel()
     {
         AddCommand = new DelegateCommand<string>(AddPattern);
         RemoveCommand = new DelegateCommand<Pattern>(RemovePattern);
-            
+
         SubfolderProcessingEnabled = Services.Settings.SubfolderProcessingEnabled;
+        SubfolderDepthLimit = Services.Settings.SubfolderDepthLimit;
         PatternsList = Services.Settings.Patterns;
     }
-        
+
     private void AddPattern(string regex)
     {
         var trimmedRegex = regex?.Trim();
@@ -54,13 +58,13 @@ public class SubfolderProcessingViewModel : BindableBase, IDialogAware
         Logger.Debug("Adding pattern: {Regex}", trimmedRegex);
         PatternsList.Add(new Pattern(trimmedRegex, true));
     }
-    
+
     private void RemovePattern(Pattern pattern)
     {
         Logger.Debug("Removing pattern: {Regex}", pattern.Regex);
         PatternsList.Remove(pattern);
     }
-    
+
     private bool IsValidPattern(string pattern)
     {
         if (!string.IsNullOrWhiteSpace(pattern)
@@ -70,12 +74,12 @@ public class SubfolderProcessingViewModel : BindableBase, IDialogAware
         }
         if (!DataUtils.IsValidRegex(pattern))
         {
-            MessageBox.Show(CustomMessageBox.Error(Lang.InvalidRegexMessage, 
+            MessageBox.Show(CustomMessageBox.Error(Lang.InvalidRegexMessage,
                 Lang.InvalidRegex));
         }
         return false;
     }
-    
+
     #region DialogMethods
 
     public DialogCloseListener RequestClose { get; }
@@ -86,6 +90,7 @@ public class SubfolderProcessingViewModel : BindableBase, IDialogAware
     {
         Services.Settings.Patterns = PatternsList;
         Services.Settings.SubfolderProcessingEnabled = SubfolderProcessingEnabled;
+        Services.Settings.SubfolderDepthLimit = SubfolderDepthLimit;
         Services.Settings.Save();
     }
 

--- a/FoliCon/Views/MainWindow.xaml
+++ b/FoliCon/Views/MainWindow.xaml
@@ -67,6 +67,12 @@
                     <CheckBox x:Name="ChkIgnoreAmbiguous" Content="{extension:Lang Key={x:Static langs:LangKeys.IgnoreAmbiguousTitle}}"
                               IsChecked="{Binding IsSkipAmbiguous}" IsEnabled="{Binding IsSkipAmbiguousEnabled}"
                               ToolTip="{extension:Lang Key={x:Static langs:LangKeys.AmbiguousTitleTooltip}}" />
+                    <CheckBox x:Name="ChkIncludeAlreadyProcessed" Content="{extension:Lang Key={x:Static langs:LangKeys.IncludeAlreadyProcessed}}"
+                              IsChecked="{Binding IncludeAlreadyProcessed}"
+                              ToolTip="{extension:Lang Key={x:Static langs:LangKeys.IncludeAlreadyProcessedTooltip}}" />
+                    <CheckBox x:Name="ChkProcessSelectedFolder" Content="{extension:Lang Key={x:Static langs:LangKeys.ProcessSelectedFolder}}"
+                              IsChecked="{Binding ProcessSelectedFolder}"
+                              ToolTip="{extension:Lang Key={x:Static langs:LangKeys.ProcessSelectedFolderTooltip}}" />
                     <Separator />
                     <MenuItem x:Name="MenuPosterIconConfigBtn" Header="{extension:Lang Key={x:Static langs:LangKeys.ChangePosterOverlay}}"
                               Command="{Binding PosterIconConfigCommand}" />

--- a/FoliCon/Views/SubfolderProcessing.xaml
+++ b/FoliCon/Views/SubfolderProcessing.xaml
@@ -36,6 +36,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Horizontal" Margin="10">
@@ -78,6 +79,14 @@
             </DataGrid.Columns>
         </DataGrid>
 
-        <CheckBox x:Name="ChkEnableFeature" IsChecked="{Binding SubfolderProcessingEnabled}" Content="{extension:Lang Key={x:Static langs:LangKeys.EnableSubfolderProcessing}}" Grid.Row="2" Margin="10" />
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="10,5,10,5"
+                    ToolTip="{extension:Lang Key={x:Static langs:LangKeys.MaxDepthTooltip}}">
+            <TextBlock Text="{extension:Lang Key={x:Static langs:LangKeys.MaxDepth}}"
+                       VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <hc:NumericUpDown Value="{Binding SubfolderDepthLimit}"
+                              Minimum="0" Maximum="100" Width="120"
+                              hc:InfoElement.Placeholder="0 = unlimited"/>
+        </StackPanel>
+        <CheckBox x:Name="ChkEnableFeature" IsChecked="{Binding SubfolderProcessingEnabled}" Content="{extension:Lang Key={x:Static langs:LangKeys.EnableSubfolderProcessing}}" Grid.Row="3" Margin="10" />
     </Grid>
 </UserControl>


### PR DESCRIPTION
## What

Add three new features for folder processing: include already-processed folders, include the selected folder itself, and configurable subfolder depth limit.

## Why

Closes #222

Users could only process child subfolders of the selected folder — the selected folder itself was skipped, and folders with existing FoliCon icons were silently excluded with no override. There was also no control over how deep subfolder processing would traverse.

## How

Three new settings added to the Settings menu:

1. **"Include folders with existing icons"** — A checkbox that, when enabled, bypasses the `.ico` file filter in `FileUtils.GetFolderNames()`, allowing re-processing of previously-iconed folders. The existing icon is deleted and recreated with the new poster image, and the temporary `.png` is properly cleaned up via a new `forceOverwrite` parameter in `IconUtils.MakeIco()`.

2. **"Include selected folder"** — A checkbox that, when enabled, processes the selected folder itself as a media item (in addition to its children). Respects the "Include already processed" flag — if a folder already has an icon and the flag is off, the folder is skipped and the user sees the "Folder already have Icons or is Empty!" message.

3. **Folder depth limit** — A `NumericUpDown` control in the Subfolder Processing dialog that limits BFS traversal depth (0 = unlimited). Changes `Queue<string>` to `Queue<(string path, int depth)>` in both `ProcessPosterFolderAsync` and `ProcessProfessionalMode`.

Both checkboxes are persisted via the `Services.Tracker` system (same as other UI settings like `IsRatingVisible`). The depth limit is persisted via `AppConfig.SubfolderDepthLimit`.

## Testing

- [x] Builds successfully (`dotnet build`)
- [x] Tested manually on Windows
- [x] No regressions observed
- [x] "Include selected folder" + "Include already processed" OFF → correctly skips folders with existing icons and shows warning message
- [x] "Include already processed" ON → re-processes folders, overwrites icons, and cleans up PNG files
- [x] Depth limit = 0 → unlimited traversal (existing behavior)
- [x] Depth limit > 0 → correctly stops at specified depth
- [x] All 8 locale files updated with proper translations (en, hi, ar, es, ja, pt, ru, zh)

## Screenshots
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/11eff5ce-76e0-4058-a2d7-946ceea71932" />


<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/4bf06cef-f5b6-4634-9c9a-79f8c6bcb71b" />
