### PR TITLE
fix #302 handycontrol language set causing deadlock

### DIFF
--- a/FoliCon/Modules/utils/CultureUtils.cs
+++ b/FoliCon/Modules/utils/CultureUtils.cs
@@ -20,7 +20,23 @@ public static class CultureUtils
         Logger.Debug("Getting CultureInfo by Language: {Language}", language);
 
         var langCode = LanguageCodes.GetValueOrDefault(language, "en-US");
-        ConfigHelper.Instance.SetLang(langCode.Split("-")[0]);
+        var pureLangCode = langCode.Split("-")[0];
+
+        // FIX: Defer the HandyControl initialization to prevent the startup deadlock.
+        // This allows the method to return the CultureInfo immediately to your view model
+        // without waiting for the uninitialized Dispatcher thread loop to finish.
+        Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+        {
+            try
+            {
+                // Now safe to initialize the static HandyControl instance
+                ConfigHelper.Instance.SetLang(pureLangCode);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Deferred internal HandyControl language configuration failed.");
+            }
+        }), DispatcherPriority.Background);
 
         return new CultureInfo(langCode);
     }


### PR DESCRIPTION
The call to `ConfigHelper.Instance` inside `CultureUtils.GetCultureInfoByLanguage()` was wrapped inside a deferred dispatcher block using `Application.Current.Dispatcher.BeginInvoke` with a priority of `DispatcherPriority.Background`. This allows the method to instantly return the `CultureInfo` to the constructor, freeing the application lifecycle to render the shell window before the HandyControl theme engine is initialized.