### PR TITLE
fix: downgrade microsoft libs from preview version 11 as they are not

### DIFF
--- a/FoliCon/FoliCon.csproj
+++ b/FoliCon/FoliCon.csproj
@@ -32,21 +32,21 @@ dineshsolanki.github.io/folicon/</Description>
     <PackageReference Include="HandyControls" Version="3.4.4" />
     <PackageReference Include="IGDB" Version="6.1.0" />
     <PackageReference Include="Jot" Version="2.1.17" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4071-prerelease" />
-    <PackageReference Include="NLog" Version="6.1.3" />
+    <PackageReference Include="NLog" Version="6.2.0" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="Prism.DryIoc" Version="9.0.537" />
     <PackageReference Include="Sentry" Version="6.6.0" />
     <PackageReference Include="Sentry.NLog" Version="6.6.0" />
-    <PackageReference Include="SharpCompress" Version="0.49.1" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="SharpCompress" Version="0.50.4" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.11" />
     <PackageReference Include="TMDbLib" Version="3.0.0" />
     <PackageReference Include="Vanara.PInvoke.Shell32" Version="5.0.5" />
     <PackageReference Include="WinCopies.IconLib" Version="0.75.0-rc" />
     <!-- Security vulnerability fixes for transitive dependencies -->
-    <PackageReference Include="System.Drawing.Common" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\icons\folicon Icon.ico" />


### PR DESCRIPTION
fix: downgrade Microsoft libs from preview version 11 as they are not compatible with dot net 10



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying libraries for improved compatibility and stability.
  * Upgraded logging and archive-processing components.
  * Aligned security, caching, and graphics components with stable platform versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->