### PR TITLE
fix: DPAPI encrypting all values instead of only secret

### DIFF
--- a/FoliCon/Modules/Configuration/AppConfig.cs
+++ b/FoliCon/Modules/Configuration/AppConfig.cs
@@ -3,7 +3,7 @@ using STJ = System.Text.Json.Serialization;
 namespace FoliCon.Modules.Configuration;
 
 [Localizable(false)]
-public class AppConfig : GlobalDataHelper
+public class AppConfig : GlobalDataHelper, STJ.IJsonOnDeserialized
 {
     // DeviantArt OAuth tokens (replaces DevClientId/DevClientSecret from client_credentials flow)
     [STJ.JsonConverter(typeof(DpapiEncryptingConverter))]
@@ -36,18 +36,24 @@ public class AppConfig : GlobalDataHelper
 
     public string ContextEntryName { get; set; } = "Create icons with FoliCon";
     public bool IsExplorerIntegrated { get; set; }
+
+    [STJ.JsonIgnore]
     public override string FileName { get; set; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),"FoliConConfig.json");
+
     private JsonSerializerOptions? _jsonSerializerOptions;
+
+    [STJ.JsonIgnore]
     public override JsonSerializerOptions JsonSerializerOptions
     {
         get => _jsonSerializerOptions ?? new JsonSerializerOptions
         {
             WriteIndented = true,
-            PropertyNameCaseInsensitive = true,
-            Converters = { new DpapiEncryptingConverter() }
+            PropertyNameCaseInsensitive = true
         };
         set => _jsonSerializerOptions = value;
     }
+
+    [STJ.JsonIgnore]
     public override int FileVersion { get; set; }
 
     public bool SubfolderProcessingEnabled { get; set; }
@@ -58,10 +64,24 @@ public class AppConfig : GlobalDataHelper
             new Pattern("Season [0-9]{1,2} Episode [0-9]{1,2}", false, true), new Pattern("\\S+", true, true)];
 
     /// <summary>
-    /// Hides <see cref="GlobalDataHelper.Save()"/> to use <see cref="DpapiPolymorphicJsonConverter{T}"/>
-    /// which tracks property names during serialization, enabling selective encryption.
-    /// The base implementation delegates to <c>JsonFile.Save</c> which adds
-    /// HandyControls' <c>PolymorphicJsonConverter</c> that doesn't track property names.
+    /// Recovers any non-secret properties that may have been erroneously encrypted
+    /// with DPAPI by legacy versions of the application.
+    /// </summary>
+    public void OnDeserialized()
+    {
+        ContextEntryName = DpapiEncryptingConverter.TryDecrypt(ContextEntryName) ?? "Create icons with FoliCon";
+        if (Patterns != null)
+        {
+            foreach (var pattern in Patterns)
+            {
+                pattern.Regex = DpapiEncryptingConverter.TryDecrypt(pattern.Regex) ?? pattern.Regex;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Saves configuration to <see cref="FileName"/>. Only properties explicitly annotated
+    /// with <see cref="DpapiEncryptingConverter"/> are encrypted at rest.
     /// </summary>
     public new void Save()
     {
@@ -70,9 +90,7 @@ public class AppConfig : GlobalDataHelper
         {
             Directory.CreateDirectory(directory);
         }
-        var options = JsonSerializerOptions;
-        options.Converters.Add(new DpapiPolymorphicJsonConverter<AppConfig>());
-        var json = System.Text.Json.JsonSerializer.Serialize(this, options);
+        var json = System.Text.Json.JsonSerializer.Serialize(this, JsonSerializerOptions);
         File.WriteAllText(FileName, json);
     }
 }

--- a/FoliCon/Modules/Configuration/DpapiEncryptingConverter.cs
+++ b/FoliCon/Modules/Configuration/DpapiEncryptingConverter.cs
@@ -6,71 +6,37 @@ using STJ = System.Text.Json.Serialization;
 namespace FoliCon.Modules.Configuration;
 
 /// <summary>
-/// JSON converter that encrypts string values at rest using Windows DPAPI (CurrentUser scope).
-/// On read: decrypts Base64-encoded DPAPI ciphertext back to plaintext.
-///   If the value cannot be decrypted (e.g. plaintext from a pre-encryption config),
-///   returns the raw value so the app doesn't crash. It will be encrypted on next save.
-/// On write: encrypts plaintext via DPAPI and writes as Base64 — but only for
-/// properties listed in <see cref="DpapiEncryptingConverterFactory.SecretProperties"/>.
-/// The property name is set via <see cref="DpapiPropertyContext.CurrentPropertyName"/>
-/// by <see cref="DpapiPolymorphicJsonConverter{T}"/> before each value is serialized.
-/// </summary>
-internal static class DpapiPropertyContext
-{
-    internal static readonly AsyncLocal<string?> CurrentPropertyName = new();
-}
-
-/// <summary>
-/// Returns <see cref="DpapiEncryptingConverter"/> for string properties whose names appear
-/// in the <see cref="SecretProperties"/> set. Before each property value is serialized,
-/// the factory sets <see cref="DpapiPropertyContext.CurrentPropertyName"/> so the shared
-/// converter instance can decide whether to encrypt.
-/// </summary>
-public sealed class DpapiEncryptingConverterFactory : STJ.JsonConverterFactory
-{
-    private static readonly DpapiEncryptingConverter Instance = new();
-
-    // NOTE: AppConfig is not directly referenced to avoid a circular assembly reference.
-    // Property names are listed explicitly so the converter only encrypts intended fields.
-    private static readonly HashSet<string> SecretProperties =
-    [
-        "DeviantArtAccessToken",
-        "DeviantArtRefreshToken",
-        "DeviantArtClientId",
-        "DeviantArtClientSecret",
-        "TmdbKey",
-        "IgdbClientId",
-        "IgdbClientSecret",
-    ];
-
-    public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(string);
-
-    public override STJ.JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
-    {
-        return Instance;
-    }
-
-    /// <summary>
-    /// Called by the custom <see cref="DpapiPolymorphicJsonConverter"/> before serializing
-    /// each property value, so the converter knows whether to encrypt.
-    /// </summary>
-    public static void SetCurrentProperty(string propertyName) => DpapiPropertyContext.CurrentPropertyName.Value = propertyName;
-
-    public static bool IsSecretProperty(string propertyName) => SecretProperties.Contains(propertyName);
-}
-
-/// <summary>
-/// Encrypts (on write) and decrypts (on read) secret string values using Windows DPAPI.
-/// Write is selective: only encrypts when <see cref="DpapiPropertyContext.CurrentPropertyName"/>
-/// is a known secret property name set by <see cref="DpapiPolymorphicJsonConverter{T}"/>.
-/// Read always attempts decryption; if it fails, returns the raw value (plaintext) so the
-/// app continues working even with pre-encryption configs.
+/// Encrypts (on write) and decrypts (on read) secret string values using Windows DPAPI (CurrentUser scope).
+/// When applied at property-level via <c>[JsonConverter(typeof(DpapiEncryptingConverter))]</c>,
+/// System.Text.Json invokes this converter only for annotated secret properties.
 /// </summary>
 public sealed class DpapiEncryptingConverter : STJ.JsonConverter<string>
 {
     public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var value = reader.GetString();
+        return TryDecrypt(value);
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            writer.WriteStringValue(value);
+            return;
+        }
+
+        var plainBytes = System.Text.Encoding.UTF8.GetBytes(value);
+        var encryptedBytes = ProtectedData.Protect(plainBytes, null, DataProtectionScope.CurrentUser);
+        writer.WriteStringValue(Convert.ToBase64String(encryptedBytes));
+    }
+
+    /// <summary>
+    /// Attempts to decrypt a DPAPI-encrypted Base64 string.
+    /// If decryption fails or the input is plaintext, returns the original value.
+    /// </summary>
+    public static string? TryDecrypt(string? value)
+    {
         if (string.IsNullOrEmpty(value))
         {
             return value;
@@ -84,74 +50,13 @@ public sealed class DpapiEncryptingConverter : STJ.JsonConverter<string>
         }
         catch (FormatException)
         {
-            // Not valid Base64 — treat as plaintext. Will be encrypted on next save.
+            // Not valid Base64 — treat as plaintext.
             return value;
         }
         catch (CryptographicException)
         {
-            // Valid Base64 but not DPAPI-encrypted — treat as plaintext. Will be encrypted on next save.
+            // Valid Base64 but not DPAPI-encrypted — treat as plaintext.
             return value;
         }
-    }
-
-    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            writer.WriteStringValue(value);
-            return;
-        }
-
-        // Only encrypt if the current property being serialized is a known secret
-        if (DpapiPropertyContext.CurrentPropertyName.Value is not null &&
-            DpapiEncryptingConverterFactory.IsSecretProperty(DpapiPropertyContext.CurrentPropertyName.Value))
-        {
-            var plainBytes = System.Text.Encoding.UTF8.GetBytes(value);
-            var encryptedBytes = ProtectedData.Protect(plainBytes, null, DataProtectionScope.CurrentUser);
-            writer.WriteStringValue(Convert.ToBase64String(encryptedBytes));
-        }
-        else
-        {
-            writer.WriteStringValue(value);
-        }
-    }
-}
-
-/// <summary>
-/// Replacement for HandyControls' <c>PolymorphicJsonConverter</c> that also tracks
-/// the current property name via <see cref="DpapiEncryptingConverterFactory"/>
-/// before serializing each value, enabling selective encryption.
-/// </summary>
-internal sealed class DpapiPolymorphicJsonConverter<T> : STJ.JsonConverter<T>
-{
-    public override bool CanConvert(Type typeToConvert) => typeof(T).IsAssignableFrom(typeToConvert);
-
-    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
-
-    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
-    {
-        if (value is null)
-        {
-            writer.WriteNullValue();
-            return;
-        }
-
-        writer.WriteStartObject();
-        foreach (var property in value.GetType().GetProperties())
-        {
-            if (!property.CanRead || property.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>() != null)
-            {
-                continue;
-            }
-
-            var propertyValue = property.GetValue(value);
-            writer.WritePropertyName(property.Name);
-
-            // Signal which property is about to be serialized so DpapiEncryptingConverter
-            // can decide whether to encrypt based on DpapiPropertyContext.CurrentPropertyName.
-            DpapiEncryptingConverterFactory.SetCurrentProperty(property.Name);
-            System.Text.Json.JsonSerializer.Serialize(writer, propertyValue, options);
-        }
-        writer.WriteEndObject();
     }
 }

--- a/FoliconTest/AppConfigTests.cs
+++ b/FoliconTest/AppConfigTests.cs
@@ -105,4 +105,85 @@ public class AppConfigTests : IDisposable
         Assert.True(File.Exists(filePath));
         Assert.False(Directory.Exists(filePath));
     }
+
+    [Fact]
+    public void Save_DoesNotEncryptUnannotatedProperties_IncludingPatterns()
+    {
+        var config = new AppConfig
+        {
+            FileName = Path.Combine(_root, "PlaintextTest.json"),
+            DeviantArtAccessToken = "secret-token",
+            ContextEntryName = "Create icons with FoliCon",
+            Patterns = [new FoliCon.Models.Data.Pattern("^[0-9]{1,2}x[0-9]{1,2}", false, true)]
+        };
+
+        config.Save();
+
+        var json = File.ReadAllText(config.FileName);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        // Annotated secret must be encrypted
+        AssertEncrypted(root, nameof(AppConfig.DeviantArtAccessToken), "secret-token");
+
+        // Unannotated string properties must remain plaintext
+        Assert.Equal("Create icons with FoliCon", root.GetProperty(nameof(AppConfig.ContextEntryName)).GetString());
+
+        var patternElement = root.GetProperty(nameof(AppConfig.Patterns))[0];
+        Assert.Equal("^[0-9]{1,2}x[0-9]{1,2}", patternElement.GetProperty("Regex").GetString());
+    }
+
+    [Fact]
+    public void OnDeserialized_RecoversLegacyEncryptedNonSecretProperties()
+    {
+        // Simulate a corrupted legacy config file where ContextEntryName and Pattern Regex were encrypted with DPAPI
+        var plainContextName = "Create icons with FoliCon";
+        var plainRegex = "^[0-9]{1,2}x[0-9]{1,2}";
+
+        var encContextBytes = System.Security.Cryptography.ProtectedData.Protect(
+            System.Text.Encoding.UTF8.GetBytes(plainContextName),
+            null,
+            System.Security.Cryptography.DataProtectionScope.CurrentUser);
+        var encRegexBytes = System.Security.Cryptography.ProtectedData.Protect(
+            System.Text.Encoding.UTF8.GetBytes(plainRegex),
+            null,
+            System.Security.Cryptography.DataProtectionScope.CurrentUser);
+
+        var encContextB64 = Convert.ToBase64String(encContextBytes);
+        var encRegexB64 = Convert.ToBase64String(encRegexBytes);
+
+        var json = $$"""
+        {
+          "DeviantArtAccessToken": null,
+          "ContextEntryName": "{{encContextB64}}",
+          "Patterns": [
+            {
+              "Regex": "{{encRegexB64}}",
+              "IsEnabled": false,
+              "IsReadOnly": true
+            }
+          ]
+        }
+        """;
+
+        var filePath = Path.Combine(_root, "CorruptedConfig.json");
+        File.WriteAllText(filePath, json);
+
+        var loaded = JsonSerializer.Deserialize<AppConfig>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(loaded);
+        loaded.FileName = filePath;
+
+        // Must be healed to plaintext
+        Assert.Equal(plainContextName, loaded.ContextEntryName);
+        Assert.Equal(plainRegex, loaded.Patterns[0].Regex);
+
+        // When saved again, must be saved as plaintext
+        loaded.Save();
+        var reSavedJson = File.ReadAllText(filePath);
+        using var document = JsonDocument.Parse(reSavedJson);
+        var root = document.RootElement;
+
+        Assert.Equal(plainContextName, root.GetProperty(nameof(AppConfig.ContextEntryName)).GetString());
+        Assert.Equal(plainRegex, root.GetProperty(nameof(AppConfig.Patterns))[0].GetProperty("Regex").GetString());
+    }
 }


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

## Why

<!-- Link to the issue this addresses -->
Closes #

## How

<!-- Key implementation details, if non-obvious -->

## Testing

- [ ] Builds successfully (`dotnet build`)
- [ ] Tested manually on Windows
- [ ] No regressions observed

## Screenshots

<!-- If UI changes, paste before/after screenshots -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now handle encrypted and non-encrypted values more consistently.
  * Sensitive configuration values remain protected when saved.

* **Bug Fixes**
  * Existing configuration files with legacy encrypted values can now be loaded successfully.
  * Previously encrypted non-sensitive values are restored and saved in readable form.

* **Tests**
  * Added coverage for configuration encryption, plaintext properties, and legacy-value recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->