### PR TITLE
cicid: add package distribution to chocolatey and winget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,3 +246,86 @@ jobs:
           # Enable auto-merge (squash) — requires "Allow auto-merge" in repo settings
           gh pr merge "$PR_URL" --auto --squash || \
             echo "::warning::Auto-merge could not be enabled. PR requires manual merge."
+
+  publish-winget:
+    name: Publish to WinGet
+    needs: [ version, release ]
+    if: needs.version.outputs.is_prerelease == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit to WinGet
+        uses: vedantmgoyal2009/winget-releaser@v2
+        if: env.WINGET_TOKEN != ''
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        with:
+          identifier: DineshSolanki.FoliCon
+          version: ${{ needs.version.outputs.version }}
+          token: ${{ secrets.WINGET_TOKEN }}
+
+      - name: Report missing WinGet secret
+        if: env.WINGET_TOKEN == ''
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: echo "::warning::WINGET_TOKEN secret is not configured in repository settings. Set WINGET_TOKEN to enable automatic WinGet updates."
+
+  publish-chocolatey:
+    name: Publish to Chocolatey
+    needs: [ version, publish, release ]
+    if: needs.version.outputs.is_prerelease == 'false'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: FoliCon-v${{ needs.version.outputs.version }}-x64
+          path: dist
+
+      - name: Pack and Push to Chocolatey
+        if: env.CHOCOLATEY_API_KEY != ''
+        shell: pwsh
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        run: |
+          $version = "${{ needs.version.outputs.version }}"
+          $zipPath = (Get-ChildItem "dist/FoliCon-v$version*-x64.zip" | Select-Object -First 1).FullName
+          $hash = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash
+
+          # Update nuspec
+          [xml]$nuspec = Get-Content "distribution/chocolatey/folicon.nuspec"
+          $nuspec.package.metadata.version = $version
+          $nuspec.Save((Resolve-Path "distribution/chocolatey/folicon.nuspec").Path)
+
+          # Update chocolateyinstall.ps1 with release tag URL and calculated hash
+          $tag = "v$version"
+          $installScript = @"
+          `$ErrorActionPreference = 'Stop'
+          `$toolsDir = "`$(Split-Path -parent `$MyInvocation.MyCommand.Definition)"
+          `$packageArgs = @{
+            packageName   = 'folicon'
+            unzipLocation = `$toolsDir
+            fileType      = 'zip'
+            url64bit      = 'https://github.com/DineshSolanki/FoliCon/releases/download/$tag/FoliCon-v$version-x64.zip'
+            checksum64    = '$hash'
+            checksumType64= 'sha256'
+          }
+          Install-ChocolateyZipPackage @packageArgs
+          "@
+          Set-Content -Path "distribution/chocolatey/tools/chocolateyinstall.ps1" -Value $installScript -Encoding UTF8
+
+          # Pack
+          choco pack distribution/chocolatey/folicon.nuspec --version $version --outputdirectory dist
+
+          # Push to Chocolatey Community Repository
+          choco push (Get-ChildItem "dist/folicon.$version.nupkg").FullName --api-key $env:CHOCOLATEY_API_KEY --source https://push.chocolatey.org/
+
+      - name: Report missing Chocolatey secret
+        if: env.CHOCOLATEY_API_KEY == ''
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        shell: pwsh
+        run: Write-Host "::warning::CHOCOLATEY_API_KEY secret is not configured in repository settings. Set CHOCOLATEY_API_KEY to enable automatic Chocolatey publishing."
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,6 +273,8 @@ jobs:
     name: Publish to Chocolatey
     needs: [ version, publish, release ]
     if: needs.version.outputs.is_prerelease == 'false'
+    permissions:
+      contents: read
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/distribution/chocolatey/folicon.nuspec
+++ b/distribution/chocolatey/folicon.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>folicon</id>
+    <version>5.3.1</version>
+    <title>FoliCon</title>
+    <authors>Dinesh Solanki</authors>
+    <projectUrl>https://dineshsolanki.github.io/FoliCon/</projectUrl>
+    <projectSourceUrl>https://github.com/DineshSolanki/FoliCon</projectSourceUrl>
+    <packageSourceUrl>https://github.com/DineshSolanki/FoliCon/tree/master/distribution/chocolatey</packageSourceUrl>
+    <docsUrl>https://dineshsolanki.github.io/FoliCon-docs/</docsUrl>
+    <bugTrackerUrl>https://github.com/DineshSolanki/FoliCon/issues</bugTrackerUrl>
+    <licenseUrl>https://raw.githubusercontent.com/DineshSolanki/FoliCon/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <iconUrl>https://raw.githubusercontent.com/dinesh-solanki/Project-Assets/master/Folicon/folicon%20Icon.png</iconUrl>
+    <tags>folicon folder-icons customization icons movie-icons plex jellyfin anime games imdb tmdb</tags>
+    <summary>Automated Movie, TV Show, Game, Anime &amp; Music Folder Icon Customizer with IMDb ratings</summary>
+    <description>FoliCon is an open-source Windows folder icon customizer for movies, TV series, anime, games, and music. It connects to TMDB, IGDB, and DeviantArt to automatically fetch high-resolution posters and ratings, compiling them into stylized folder icons in real time.</description>
+    <releaseNotes>https://github.com/DineshSolanki/FoliCon/releases/tag/V5.3.1</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/distribution/chocolatey/tools/chocolateyinstall.ps1
+++ b/distribution/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,52 @@
+Continue = 'Stop'
+ = "$nuspec = @(
+"<?xml version=""1.0"" encoding=""utf-8""?>",
+"<package xmlns=""http:\\schemas.microsoft.com\packaging\2015\06\nuspec.xsd"">",
+"  <metadata>",
+"    <id>folicon<\id>",
+"    <version>5.3.1<\version>",
+"    <title>FoliCon<\title>",
+"    <authors>Dinesh Solanki<\authors>",
+"    <projectUrl>https:\\dineshsolanki.github.io\FoliCon\<\projectUrl>",
+"    <projectSourceUrl>https:\\github.com\DineshSolanki\FoliCon<\projectSourceUrl>",
+"    <packageSourceUrl>https:\\github.com\DineshSolanki\FoliCon\tree\master\distribution\chocolatey<\packageSourceUrl>",
+"    <docsUrl>https:\\dineshsolanki.github.io\FoliCon-docs\<\docsUrl>",
+"    <bugTrackerUrl>https:\\github.com\DineshSolanki\FoliCon\issues<\bugTrackerUrl>",
+"    <licenseUrl>https:\\raw.githubusercontent.com\DineshSolanki\FoliCon\master\LICENSE<\licenseUrl>",
+"    <requireLicenseAcceptance>false<\requireLicenseAcceptance>",
+"    <iconUrl>https:\\raw.githubusercontent.com\dinesh-solanki\Project-Assets\master\Folicon\folicon%20Icon.png<\iconUrl>",
+"    <tags>folicon folder-icons customization icons movie-icons plex jellyfin anime games imdb tmdb<\tags>",
+"    <summary>Automated Movie, TV Show, Game, Anime &amp; Music Folder Icon Customizer with IMDb ratings<\summary>",
+"    <description>FoliCon is an open-source Windows folder icon customizer for movies, TV series, anime, games, and music. It connects to TMDB, IGDB, and DeviantArt to automatically fetch high-resolution posters and ratings, compiling them into stylized folder icons in real time.<\description>",
+"    <releaseNotes>https:\\github.com\DineshSolanki\FoliCon\releases\tag\V5.3.1<\releaseNotes>",
+"  <\metadata>",
+"  <files>",
+"    <file src=""tools\**"" target=""tools"" \>",
+"  <\files>",
+"<\package>"
+)
+$nuspec | Set-Content -Path "distribution\chocolatey\folicon.nuspec"
+
+$install = @(
+"$ErrorActionPreference = 'Stop'",
+"$toolsDir = ""$(Split-Path -parent $MyInvocation.MyCommand.Definition)""",
+"$packageArgs = @{",
+"  packageName   = 'folicon'",
+"  unzipLocation = $toolsDir",
+"  fileType      = 'zip'",
+"  url64bit      = 'https:\\github.com\DineshSolanki\FoliCon\releases\download\V5.3.1\FoliCon-v5.3.1-x64.zip'",
+"  checksum64    = '48510B29B40BD0D988C3EA889946E0C4D4D67A8D54FE5DACC412489EE72EC129'",
+"  checksumType64= 'sha256'",
+"}",
+"Install-ChocolateyZipPackage @packageArgs"
+)
+$install | Set-Content -Path "distribution\chocolatey\tools"
+ = @{
+  packageName   = 'folicon'
+  unzipLocation = 
+  fileType      = 'zip'
+  url64bit      = 'https://github.com/DineshSolanki/FoliCon/releases/download/V5.3.1/FoliCon-v5.3.1-x64.zip'
+  checksum64    = '48510B29B40BD0D988C3EA889946E0C4D4D67A8D54FE5DACC412489EE72EC129'
+  checksumType64= 'sha256'
+}
+Install-ChocolateyZipPackage @packageArgs

--- a/distribution/winget/manifests/d/DineshSolanki/FoliCon/5.3.1/DineshSolanki.FoliCon.installer.yaml
+++ b/distribution/winget/manifests/d/DineshSolanki/FoliCon/5.3.1/DineshSolanki.FoliCon.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: DineshSolanki.FoliCon
+PackageVersion: 5.3.1
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: FoliCon.exe
+  PortableCommandAlias: folicon
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DineshSolanki/FoliCon/releases/download/V5.3.1/FoliCon-v5.3.1-x64.zip
+  InstallerSha256: 48510B29B40BD0D988C3EA889946E0C4D4D67A8D54FE5DACC412489EE72EC129
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/distribution/winget/manifests/d/DineshSolanki/FoliCon/5.3.1/DineshSolanki.FoliCon.locale.en-US.yaml
+++ b/distribution/winget/manifests/d/DineshSolanki/FoliCon/5.3.1/DineshSolanki.FoliCon.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: DineshSolanki.FoliCon
+PackageVersion: 5.3.1
+PackageLocale: en-US
+Publisher: Dinesh Solanki
+PublisherUrl: https://github.com/DineshSolanki
+PublisherSupportUrl: https://github.com/DineshSolanki/FoliCon/issues
+Author: Dinesh Solanki
+PackageName: FoliCon
+PackageUrl: https://dineshsolanki.github.io/FoliCon/
+License: GPL-3.0
+LicenseUrl: https://raw.githubusercontent.com/DineshSolanki/FoliCon/master/LICENSE
+Copyright: Copyright (c) Dinesh Solanki
+ShortDescription: Automated Movie, TV Show, Game, Anime & Music Folder Icon Customizer with IMDb ratings.
+Description: FoliCon is a Windows folder icon customizer for movies, TV series, anime, games, and music. It automatically searches online metadata providers (TMDB, IGDB, DeviantArt), fetches high-resolution poster art and ratings, and generates stylized Windows folder icons with custom overlays.
+Moniker: folicon
+Tags:
+- anime
+- customization
+- desktop-customization
+- folder-icons
+- games
+- icon-changer
+- imdb
+- movie-icons
+- movies
+- tmdb
+ReleaseNotesUrl: https://github.com/DineshSolanki/FoliCon/releases/tag/V5.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/distribution/winget/manifests/d/DineshSolanki/FoliCon/5.3.1/DineshSolanki.FoliCon.yaml
+++ b/distribution/winget/manifests/d/DineshSolanki/FoliCon/5.3.1/DineshSolanki.FoliCon.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: =https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: DineshSolanki.FoliCon
+PackageVersion: 5.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Windows package distribution through WinGet for FoliCon version 5.3.1.
  - Added Chocolatey package distribution for FoliCon version 5.3.1.
  - Published portable x64 installation metadata, command alias, download details, and release information for supported Windows systems.
- **Chores**
  - Automated publishing to WinGet and Chocolatey as part of the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->